### PR TITLE
Add isZoomed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,21 @@ function MyComponent(props) {
 }
 ```
 
-The component accepts three props:
-* `image` [ object | required ]: the original image
-* `zoomImage` [ object | optional ]: the image to be used for zooming
-* `replaceImage` [ boolean | optional | default `true` ]: once the image has been "zoomed" and downloaded the larger image, replace the original image. This is set to `true` by default.
+| Prop | Type | Required | Default | Details |
+| ------ |  ---- | ------- | ------- | ------- |
+| `image` | object | yes | none | The original image |
+| `zoomImage` | object | no | `image` | The image to be used for zooming |
+| `isZoomed` | boolean | no | `false` | For more direct control over the zoom state |
+| `replaceImage` | boolean | no | `true` | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
 
 Each one of these image props accepts normal `image` props, for example:
-* `src` [ string | required ]: the source for the image
-* `alt` [ string | optional ]: the alt text for the image
-* `className` [ string | optional ]: classes to apply to the image
-* `style` [ object | optional ]: additional styles to apply to the image
+| Prop | Type | Required | Details |
+| ------ |  ---- | ------- | ------- |
+| `src` | string | yes | The source for the image |
+| `alt` | string | no | The alt text for the image |
+| `className` | string | no | Classes to apply to the image |
+| `style` | object | no | Additional styles to apply to the image |
+| ... | ... | no | ... |
 
 ## Browser Support
 Currently, this has only been tested on the latest modern browsers. Pull requests are welcome.

--- a/example/app.js
+++ b/example/app.js
@@ -248,7 +248,7 @@ var ImageZoom = function (_Component) {
     var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(ImageZoom).call(this, props));
 
     _this.state = {
-      isZoomed: false,
+      isZoomed: props.isZoomed,
       src: null
     };
 
@@ -262,16 +262,21 @@ var ImageZoom = function (_Component) {
     value: function componentDidMount() {
       this.portal = document.createElement('div');
       document.body.appendChild(this.portal);
+      if (this.state.isZoomed) this.renderZoomed();
     }
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       document.body.removeChild(this.portal);
+      delete this.portal;
+      delete this.portalInstance;
     }
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps, prevState) {
-      if (prevState.isZoomed !== this.state.isZoomed) {
+      if (prevProps.isZoomed !== this.props.isZoomed && this.portalInstance) {
+        this.props.isZoomed ? this.renderZoomed() : this.portalInstance.handleUnzoom();
+      } else if (prevState.isZoomed !== this.state.isZoomed) {
         this.state.isZoomed ? this.renderZoomed() : this.removeZoomed();
       }
     }
@@ -291,7 +296,7 @@ var ImageZoom = function (_Component) {
     value: function renderZoomed() {
       var image = _reactDom2.default.findDOMNode(this);
 
-      _reactDom2.default.render(_react2.default.createElement(Zoom, _extends({}, this.props.zoomImage, {
+      this.portalInstance = _reactDom2.default.render(_react2.default.createElement(Zoom, _extends({}, this.props.zoomImage, {
         image: image,
         hasAlreadyLoaded: !!this.state.src,
         onClick: this.handleUnzoom
@@ -329,6 +334,7 @@ var ImageZoom = function (_Component) {
     key: 'defaultProps',
     get: function get() {
       return {
+        isZoomed: false,
         shouldReplaceImage: true
       };
     }
@@ -352,6 +358,7 @@ ImageZoom.propTypes = {
     className: string,
     style: object
   }),
+  isZoomed: bool,
   shouldReplaceImage: bool
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "Medium.com style image zoom for React",
   "main": "lib/react-medium-image-zoom.js",
   "scripts": {

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -44,7 +44,7 @@ export default class ImageZoom extends Component {
     super(props)
 
     this.state = {
-      isZoomed: false,
+      isZoomed: props.isZoomed,
       src: null
     }
 
@@ -54,6 +54,7 @@ export default class ImageZoom extends Component {
 
   static get defaultProps() {
     return {
+      isZoomed: false,
       shouldReplaceImage: true
     }
   }
@@ -61,14 +62,19 @@ export default class ImageZoom extends Component {
   componentDidMount() {
     this.portal = document.createElement('div')
     document.body.appendChild(this.portal)
+    if (this.state.isZoomed) this.renderZoomed()
   }
 
   componentWillUnmount() {
     document.body.removeChild(this.portal)
+    delete this.portal;
+    delete this.portalInstance;
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (prevState.isZoomed !== this.state.isZoomed) {
+    if (prevProps.isZoomed !== this.props.isZoomed && this.portalInstance) {
+      this.props.isZoomed ? this.renderZoomed() : this.portalInstance.handleUnzoom()
+    } else if (prevState.isZoomed !== this.state.isZoomed) {
       this.state.isZoomed ? this.renderZoomed() : this.removeZoomed()
     }
   }
@@ -88,7 +94,7 @@ export default class ImageZoom extends Component {
   renderZoomed() {
     const image = ReactDOM.findDOMNode(this)
 
-    ReactDOM.render(
+    this.portalInstance = ReactDOM.render(
       <Zoom
         { ...this.props.zoomImage }
         image={ image }
@@ -134,6 +140,7 @@ ImageZoom.propTypes = {
     className: string,
     style: object
   }),
+  isZoomed: bool,
   shouldReplaceImage: bool
 }
 


### PR DESCRIPTION
fixes #12 

* * *

# What this is
This PR should let consumers manually be able to trigger the zoomed state in order to manually open or close it without having to do a hacky click event.

## Use case 1
Let's say you have an interface that uses tabs to view different pages. Each tab triggers a `pushState` event so that you can link straight to a given tab; however, instead of blowing away the React elements and rendering a whole new set, you use CSS to hide what shouldn't be visible. The issue arises when you zoom an image and then hit the back button -- the component never unmounts, and therefore you never close the zoom image.

## Use case 2
You want to deep link to a zoomed image. On one hand, you could trigger a click manually, but that doesn't seem like the React way, so instead you want to pass an option that says, "Hey, go ahead and zoom/open this image right when you load."

* * *

Thus, it makes sense to add a manual trigger.