### PR TITLE
Accept new src

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -279,7 +279,6 @@ var ImageZoom = function (_Component) {
   }, {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
-      console.log(nextProps.image.src);
       if (this.props.image.src !== nextProps.image.src) {
         this.setState({ src: nextProps.image.src });
       }

--- a/example/app.js
+++ b/example/app.js
@@ -277,6 +277,14 @@ var ImageZoom = function (_Component) {
       delete this.portalInstance;
     }
   }, {
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(nextProps) {
+      console.log(nextProps.image.src);
+      if (this.props.image.src !== nextProps.image.src) {
+        this.setState({ src: nextProps.image.src });
+      }
+    }
+  }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps, prevState) {
       if (prevProps.isZoomed !== this.props.isZoomed && this.portalInstance) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Medium.com style image zoom for React",
   "main": "lib/react-medium-image-zoom.js",
   "scripts": {

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -73,6 +73,12 @@ export default class ImageZoom extends Component {
     delete this.portalInstance;
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.image.src !== nextProps.image.src) {
+      this.setState({ src: nextProps.image.src })
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.isZoomed !== this.props.isZoomed && this.portalInstance) {
       this.props.isZoomed ? this.renderZoomed() : this.portalInstance.handleUnzoom()


### PR DESCRIPTION
Fixes an issue where if the component isn't destroyed but instead passed a new `src`, it wasn't accepting and using that new `src` and instead was using what was stored in `state`.