### PR TITLE
Should handle zoom func

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ function MyComponent(props) {
 | `shouldReplaceImage`        | boolean | no       | `true`  | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
 | `shouldRespectMaxDimension` | boolean | no       | `false` | When true, don't make the zoomed image's dimensions larger than the original dimensions. _Currently only supported when NO zoomImage is provided._  |
 | `defaultStyles`             | object  | no       | `{}`    | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |
+| `shouldHandleZoom`          | func    | no       | `(event) => true` | Pass this callback to intercept a zoom click event and determine whether or not to zoom. Function must return a truthy or falsy value |
 
 Each one of these image props accepts normal `image` props, for example:
 

--- a/example/app.js
+++ b/example/app.js
@@ -204,9 +204,10 @@ function _inherits(subClass, superClass) {
 }
 
 var bool = _react.PropTypes.bool;
+var func = _react.PropTypes.func;
+var object = _react.PropTypes.object;
 var shape = _react.PropTypes.shape;
 var string = _react.PropTypes.string;
-var object = _react.PropTypes.object;
 
 var transitionDuration = 300;
 
@@ -331,8 +332,10 @@ var ImageZoom = function (_Component) {
     }
   }, {
     key: 'handleZoom',
-    value: function handleZoom() {
-      this.setState({ isZoomed: true });
+    value: function handleZoom(event) {
+      if (this.props.shouldHandleZoom(event)) {
+        this.setState({ isZoomed: true });
+      }
     }
   }, {
     key: 'handleUnzoom',
@@ -358,6 +361,9 @@ var ImageZoom = function (_Component) {
           overlay: {},
           image: {},
           zoomImage: {}
+        },
+        shouldHandleZoom: function shouldHandleZoom(_) {
+          return true;
         }
       };
     }
@@ -384,7 +390,8 @@ ImageZoom.propTypes = {
   defaultStyles: object,
   isZoomed: bool,
   shouldReplaceImage: bool,
-  shouldRespectMaxDimension: bool
+  shouldRespectMaxDimension: bool,
+  shouldHandleZoom: func
 };
 
 //====================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Medium.com style image zoom for React",
   "main": "lib/react-medium-image-zoom.js",
   "scripts": {

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import ReactDOM from 'react-dom'
 
-const { bool, shape, string, object } = PropTypes
+const { bool, func, object, shape, string } = PropTypes
 
 const transitionDuration = 300
 
@@ -63,7 +63,8 @@ export default class ImageZoom extends Component {
         overlay: {},
         image: {},
         zoomImage: {}
-      }
+      },
+      shouldHandleZoom: (_) => true
     }
   }
 
@@ -137,8 +138,10 @@ export default class ImageZoom extends Component {
     )
   }
 
-  handleZoom() {
-    this.setState({ isZoomed: true })
+  handleZoom(event) {
+    if (this.props.shouldHandleZoom(event)) {
+      this.setState({ isZoomed: true })
+    }
   }
 
   handleUnzoom(src) {
@@ -166,7 +169,8 @@ ImageZoom.propTypes = {
   defaultStyles: object,
   isZoomed: bool,
   shouldReplaceImage: bool,
-  shouldRespectMaxDimension: bool
+  shouldRespectMaxDimension: bool,
+  shouldHandleZoom: func
 }
 
 //====================================================


### PR DESCRIPTION
Allows for the component to accept a function that will call back and ask, if provided, whether or not to actually zoom  the image on a click. The issue, #24, makes a good case: sometimes you want to not zoom if you are doing shift + click or control + click, etc. Here's the API for usage:

```js
<ImageZoom
  // ...
  shouldHandleZoom={(e) => {
    if (e.shiftKey) return false;
    return true;
  }}
/>
```
cc @rsaccon