### PR TITLE
Look for image change by comparing props

### DIFF
--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -81,7 +81,7 @@ export default class ImageZoom extends Component {
   // We need to check to see if any changes are being
   // mandated by the consumer and if so, update accordingly
   componentWillReceiveProps(nextProps) {
-    const imageChanged = this.state.image.src !== nextProps.image.src
+    const imageChanged = this.props.image.src !== nextProps.image.src
     const isZoomedChanged = this.props.isZoomed !== nextProps.isZoomed
     const changes = Object.assign({},
       imageChanged && { image: nextProps.image },


### PR DESCRIPTION
Since `state.image.src` is replaced by a high-res version when `handleUnzoom` is called, checking for an image change by comparing `nextProps` to `this.state` will always return true. The result is that the high-res image is replaced by the low-res and left that way.