### PR TITLE
Adds optional onZoom and onUnzoom callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ function MyComponent(props) {
 | `shouldRespectMaxDimension` | boolean | no       | `false` | When true, don't make the zoomed image's dimensions larger than the original dimensions. _Currently only supported when NO zoomImage is provided._  |
 | `defaultStyles`             | object  | no       | `{}`    | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |
 | `shouldHandleZoom`          | func    | no       | `(event) => true` | Pass this callback to intercept a zoom click event and determine whether or not to zoom. Function must return a truthy or falsy value |
+| `onZoom`                    | func    | no       | `() => {}`        | Pass this callback to respond to a zoom interaction. |
+| `onUnzoom`                  | func    | no       | `() => {}`        | Pass this callback to respond to an unzoom interaction. |
 
 Each one of these image props accepts normal `image` props, for example:
 

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -65,7 +65,9 @@ export default class ImageZoom extends Component {
         image: {},
         zoomImage: {}
       },
-      shouldHandleZoom: (_) => true
+      shouldHandleZoom: (_) => true,
+      onZoom: () => {},
+      onUnzoom: () => {}
     }
   }
 
@@ -164,6 +166,7 @@ export default class ImageZoom extends Component {
   handleZoom(event) {
     if (this.props.shouldHandleZoom(event)) {
       this.setState({ isZoomed: true })
+      this.props.onZoom()
     }
   }
 
@@ -193,6 +196,7 @@ export default class ImageZoom extends Component {
       this.removeZoomed()
 
       this.setState(changes)
+      this.props.onUnzoom()
     }
   }
 }
@@ -214,7 +218,9 @@ ImageZoom.propTypes = {
   isZoomed: bool,
   shouldReplaceImage: bool,
   shouldRespectMaxDimension: bool,
-  shouldHandleZoom: func
+  shouldHandleZoom: func,
+  onZoom: func,
+  onUnzoom: func
 }
 
 //====================================================

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -165,8 +165,7 @@ export default class ImageZoom extends Component {
 
   handleZoom(event) {
     if (this.props.shouldHandleZoom(event)) {
-      this.setState({ isZoomed: true })
-      this.props.onZoom()
+      this.setState({ isZoomed: true }, this.props.onZoom)
     }
   }
 
@@ -195,8 +194,7 @@ export default class ImageZoom extends Component {
        */
       this.removeZoomed()
 
-      this.setState(changes)
-      this.props.onUnzoom()
+      this.setState(changes, this.props.onUnzoom)
     }
   }
 }


### PR DESCRIPTION
I would like to be able to respond to the user zooming or dismissing the image. This PR adds two simple props of type `func` which default to `() => {}` and are called from `handleZoom()` and `handleUnzoom()` respectively.