### PR TITLE
Fix external isZoomed issue and also fix unzoom being called twice.

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -26,13 +26,40 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var App = function (_Component) {
   _inherits(App, _Component);
 
-  function App() {
+  function App(props) {
     _classCallCheck(this, App);
 
-    return _possibleConstructorReturn(this, (App.__proto__ || Object.getPrototypeOf(App)).apply(this, arguments));
+    var _this = _possibleConstructorReturn(this, (App.__proto__ || Object.getPrototypeOf(App)).call(this, props));
+
+    _this.state = { firstActive: false };
+    return _this;
   }
 
   _createClass(App, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      /**
+       * This is an example demonstrating how to manually
+       * control the `isZoomed` state of the first image
+       * using the `j` and `k` keys
+       */
+      document.addEventListener('keyup', this.handleKeyup.bind(this));
+    }
+  }, {
+    key: 'handleKeyup',
+    value: function handleKeyup(e) {
+      switch (e.keyCode) {
+        case 74:
+          return this.setState({ firstActive: true });
+
+        case 75:
+          return this.setState({ firstActive: false });
+
+        default:
+          return;
+      }
+    }
+  }, {
     key: 'render',
     value: function render() {
       return _react2.default.createElement(
@@ -66,7 +93,8 @@ var App = function (_Component) {
               src: 'bridge-big.jpg',
               alt: 'Golden Gate Bridge',
               className: 'img--zoomed'
-            }
+            },
+            isZoomed: this.state.firstActive
           })
         ),
         _react2.default.createElement(
@@ -278,14 +306,16 @@ var ImageZoom = function (_Component) {
       this.removeZoomed();
     }
 
-    // We need to check to see if any changes are being
-    // mandated by the consumer and if so, update accordingly
+    /**
+     * We need to check to see if any changes are being
+     * mandated by the consumer and if so, update accordingly
+     */
 
   }, {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
-      var imageChanged = this.state.image.src !== nextProps.image.src;
-      var isZoomedChanged = this.props.isZoomed !== nextProps.isZoomed;
+      var imageChanged = this.props.image.src !== nextProps.image.src;
+      var isZoomedChanged = this.state.isZoomed !== nextProps.isZoomed;
       var changes = _extends({}, imageChanged && { image: nextProps.image }, isZoomedChanged && { isZoomed: nextProps.isZoomed });
 
       if (Object.keys(changes).length) {
@@ -293,8 +323,10 @@ var ImageZoom = function (_Component) {
       }
     }
 
-    // When the component's state updates, check for changes
-    // and either zoom or start the unzoom procedure
+    /**
+     * When the component's state updates, check for changes
+     * and either zoom or start the unzoom procedure
+     */
 
   }, {
     key: 'componentDidUpdate',
@@ -358,12 +390,14 @@ var ImageZoom = function (_Component) {
       }
     }
 
-    // This gets passed to the zoomed component as a callback
-    // to trigger when the time is right to shut down the zoom.
-    // If `shouldReplaceImage`, update the normal image we're showing
-    // with the zoomed image -- useful when wanting to replace a low-res
-    // image with a high-res one once it's already been downloaded.
-    // Once `setState` runs, then run the removeZoomed cleanup function.
+    /**
+     * This gets passed to the zoomed component as a callback
+     * to trigger when the time is right to shut down the zoom.
+     * If `shouldReplaceImage`, update the normal image we're showing
+     * with the zoomed image -- useful when wanting to replace a low-res
+     * image with a high-res one once it's already been downloaded.
+     * It also cleans up the zoom references and then updates state.
+     */
 
   }, {
     key: 'handleUnzoom',
@@ -372,7 +406,17 @@ var ImageZoom = function (_Component) {
 
       return function () {
         var changes = _extends({}, { isZoomed: false }, { hasAlreadyLoaded: true }, _this2.props.shouldReplaceImage && { image: _extends({}, _this2.state.image, { src: src }) });
-        _this2.setState(changes, _this2.removeZoomed);
+
+        /**
+         * Lamentable but necessary right now in order to
+         * remove the portal instance before the next
+         * `componentDidUpdate` check for the portalInstance.
+         * The reasoning is so we can differentiate between an
+         * external `isZoomed` command and an internal one.
+         */
+        _this2.removeZoomed();
+
+        _this2.setState(changes);
       };
     }
   }], [{

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -3,6 +3,34 @@ import ReactDOM from 'react-dom'
 import ImageZoom from '../../lib/react-medium-image-zoom'
 
 class App extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = { firstActive: false }
+  }
+
+  componentDidMount() {
+    /**
+     * This is an example demonstrating how to manually
+     * control the `isZoomed` state of the first image
+     * using the `j` and `k` keys
+     */
+    document.addEventListener('keyup', this.handleKeyup.bind(this))
+  }
+
+  handleKeyup(e) {
+    switch (e.keyCode) {
+      case 74:
+        return this.setState({ firstActive: true })
+
+      case 75:
+        return this.setState({ firstActive: false })
+
+      default:
+        return
+    }
+  }
+
   render() {
     return (
       <div className="container">
@@ -21,6 +49,7 @@ class App extends Component {
               alt: 'Golden Gate Bridge',
               className: 'img--zoomed'
             }}
+            isZoomed={ this.state.firstActive }
           />
         </div>
         <p>Thundercats freegan Truffaut, four loko twee Austin scenester lo-fi seitan High Life paleo quinoa cray. Schlitz butcher ethical Tumblr, pop-up DIY keytar ethnic iPhone PBR sriracha. Tonx direct trade bicycle rights gluten-free flexitarian asymmetrical. Whatever drinking vinegar PBR XOXO Bushwick gentrify. Cliche semiotics banjo retro squid Wes Anderson. Fashion axe dreamcatcher you probably haven't heard of them bicycle rights. Tote bag organic four loko ethical selfies gastropub, PBR fingerstache tattooed bicycle rights.</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Medium.com style image zoom for React",
   "main": "lib/react-medium-image-zoom.js",
   "scripts": {

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -78,11 +78,13 @@ export default class ImageZoom extends Component {
     this.removeZoomed()
   }
 
-  // We need to check to see if any changes are being
-  // mandated by the consumer and if so, update accordingly
+  /**
+   * We need to check to see if any changes are being
+   * mandated by the consumer and if so, update accordingly
+   */
   componentWillReceiveProps(nextProps) {
     const imageChanged = this.props.image.src !== nextProps.image.src
-    const isZoomedChanged = this.props.isZoomed !== nextProps.isZoomed
+    const isZoomedChanged = this.state.isZoomed !== nextProps.isZoomed
     const changes = Object.assign({},
       imageChanged && { image: nextProps.image },
       isZoomedChanged && { isZoomed : nextProps.isZoomed }
@@ -93,8 +95,10 @@ export default class ImageZoom extends Component {
     }
   }
 
-  // When the component's state updates, check for changes
-  // and either zoom or start the unzoom procedure
+  /**
+   * When the component's state updates, check for changes
+   * and either zoom or start the unzoom procedure
+   */
   componentDidUpdate(_, prevState) {
     if (prevState.isZoomed !== this.state.isZoomed) {
       if (this.state.isZoomed) this.renderZoomed()
@@ -160,12 +164,14 @@ export default class ImageZoom extends Component {
     }
   }
 
-  // This gets passed to the zoomed component as a callback
-  // to trigger when the time is right to shut down the zoom.
-  // If `shouldReplaceImage`, update the normal image we're showing
-  // with the zoomed image -- useful when wanting to replace a low-res
-  // image with a high-res one once it's already been downloaded.
-  // Once `setState` runs, then run the removeZoomed cleanup function.
+  /**
+   * This gets passed to the zoomed component as a callback
+   * to trigger when the time is right to shut down the zoom.
+   * If `shouldReplaceImage`, update the normal image we're showing
+   * with the zoomed image -- useful when wanting to replace a low-res
+   * image with a high-res one once it's already been downloaded.
+   * It also cleans up the zoom references and then updates state.
+   */
   handleUnzoom(src) {
     return () => {
       const changes = Object.assign({},
@@ -173,7 +179,17 @@ export default class ImageZoom extends Component {
         { hasAlreadyLoaded: true },
         this.props.shouldReplaceImage && { image: Object.assign({}, this.state.image, { src }) }
       )
-      this.setState(changes, this.removeZoomed)
+
+      /**
+       * Lamentable but necessary right now in order to
+       * remove the portal instance before the next
+       * `componentDidUpdate` check for the portalInstance.
+       * The reasoning is so we can differentiate between an
+       * external `isZoomed` command and an internal one.
+       */
+      this.removeZoomed()
+
+      this.setState(changes)
     }
   }
 }


### PR DESCRIPTION
* Adds an example that allows you to use the `j` and `k` keys to zoom & unzoom the first image, respectively. 
* This example pointed out a bug where using the keys to open/close (aka, external commands) and also the click to open/close got out of sync.
* Also fixes an issue where `componentDidUpdate` was calling the `Zoom` component's `handleUnzoom` which in turn triggers the main component's `handleUnzoom`. 

cc @cbothner 
