### PR TITLE
Rebuild example and 0.8

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -389,7 +389,7 @@ var ImageZoom = function (_Component) {
     key: 'handleZoom',
     value: function handleZoom(event) {
       if (this.props.shouldHandleZoom(event)) {
-        this.setState({ isZoomed: true });
+        this.setState({ isZoomed: true }, this.props.onZoom);
       }
     }
 
@@ -419,7 +419,7 @@ var ImageZoom = function (_Component) {
          */
         _this2.removeZoomed();
 
-        _this2.setState(changes);
+        _this2.setState(changes, _this2.props.onUnzoom);
       };
     }
   }], [{
@@ -438,7 +438,9 @@ var ImageZoom = function (_Component) {
         },
         shouldHandleZoom: function shouldHandleZoom(_) {
           return true;
-        }
+        },
+        onZoom: function onZoom() {},
+        onUnzoom: function onUnzoom() {}
       };
     }
   }]);
@@ -465,7 +467,9 @@ ImageZoom.propTypes = {
   isZoomed: bool,
   shouldReplaceImage: bool,
   shouldRespectMaxDimension: bool,
-  shouldHandleZoom: func
+  shouldHandleZoom: func,
+  onZoom: func,
+  onUnzoom: func
 };
 
 //====================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Medium.com style image zoom for React",
   "main": "lib/react-medium-image-zoom.js",
   "scripts": {


### PR DESCRIPTION
@cbothner: forgot to get you to run `npm run build:example` to get the example's output up to date with the component. My bad!

Also adds a bump to version `0.8.0` because of the functionality added.