### PR TITLE
shouldPreload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ function MyComponent(props) {
 | `zoomImage`                 | object  | no       | `image` | The image to be used for zooming |
 | `zoomMargin`                | number  | no       | `40`    | Pixel number to offset zoomed image from the window |
 | `isZoomed`                  | boolean | no       | `false` | For more direct control over the zoom state |
-| `shouldReplaceImage`        | boolean | no       | `true`  | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
-| `shouldRespectMaxDimension` | boolean | no       | `false` | When true, don't make the zoomed image's dimensions larger than the original dimensions. _Currently only supported when NO zoomImage is provided._  |
-| `defaultStyles`             | object  | no       | `{}`    | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |
 | `shouldHandleZoom`          | func    | no       | `(event) => true` | Pass this callback to intercept a zoom click event and determine whether or not to zoom. Function must return a truthy or falsy value |
-| `onZoom`                    | func    | no       | `() => {}`        | Pass this callback to respond to a zoom interaction. |
-| `onUnzoom`                  | func    | no       | `() => {}`        | Pass this callback to respond to an unzoom interaction. |
+| `shouldPreload`             | bool    | no       | `false` | When `true` and `zoomImage` is included, preload the `zoomImage.src` by including a `<link rel="preload">` for image's source |
+| `shouldReplaceImage`        | boolean | no       | `true`  | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
+| `shouldRespectMaxDimension` | boolean | no       | `false` | When `true`, don't make the zoomed image's dimensions larger than the original dimensions. _Currently only supported when NO zoomImage is provided._  |
+| `defaultStyles`             | object  | no       | `{}` | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |
+| `onZoom`                    | func    | no       | `() => {}` | Pass this callback to respond to a zoom interaction. |
+| `onUnzoom`                  | func    | no       | `() => {}` | Pass this callback to respond to an unzoom interaction. |
 
 Each one of these image props accepts normal `image` props, for example:
 

--- a/example/app.js
+++ b/example/app.js
@@ -94,7 +94,8 @@ var App = function (_Component) {
               alt: 'Golden Gate Bridge',
               className: 'img--zoomed'
             },
-            isZoomed: this.state.firstActive
+            isZoomed: this.state.firstActive,
+            shouldPreload: true
           })
         ),
         _react2.default.createElement(
@@ -347,7 +348,13 @@ var ImageZoom = function (_Component) {
         onClick: this.handleZoom
       });
 
-      return _react2.default.createElement('img', attrs);
+      var image = _react2.default.createElement('img', _extends({ ref: 'image' }, attrs));
+
+      if (this.props.shouldPreload && this.props.zoomImage && this.props.zoomImage.src) {
+        return _react2.default.createElement('span', null, _react2.default.createElement('link', { rel: 'preload', href: this.props.zoomImage.src, as: 'image' }), image);
+      }
+
+      return image;
     }
 
     // Side-effects!
@@ -357,7 +364,7 @@ var ImageZoom = function (_Component) {
     value: function renderZoomed() {
       this.portal = createPortal('div');
       this.portalInstance = _reactDom2.default.render(_react2.default.createElement(Zoom, _extends({}, this.props.zoomImage, {
-        image: _reactDom2.default.findDOMNode(this),
+        image: _reactDom2.default.findDOMNode(this.refs.image),
         defaultStyles: this.props.defaultStyles,
         hasAlreadyLoaded: this.state.hasAlreadyLoaded,
         shouldRespectMaxDimension: this.props.shouldRespectMaxDimension,
@@ -465,9 +472,10 @@ ImageZoom.propTypes = {
   }),
   defaultStyles: object,
   isZoomed: bool,
+  shouldHandleZoom: func,
+  shouldPreload: bool,
   shouldReplaceImage: bool,
   shouldRespectMaxDimension: bool,
-  shouldHandleZoom: func,
   onZoom: func,
   onUnzoom: func
 };

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -50,6 +50,7 @@ class App extends Component {
               className: 'img--zoomed'
             }}
             isZoomed={ this.state.firstActive }
+            shouldPreload={true}
           />
         </div>
         <p>Thundercats freegan Truffaut, four loko twee Austin scenester lo-fi seitan High Life paleo quinoa cray. Schlitz butcher ethical Tumblr, pop-up DIY keytar ethnic iPhone PBR sriracha. Tonx direct trade bicycle rights gluten-free flexitarian asymmetrical. Whatever drinking vinegar PBR XOXO Bushwick gentrify. Cliche semiotics banjo retro squid Wes Anderson. Fashion axe dreamcatcher you probably haven't heard of them bicycle rights. Tote bag organic four loko ethical selfies gastropub, PBR fingerstache tattooed bicycle rights.</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Medium.com style image zoom for React",
   "main": "lib/react-medium-image-zoom.js",
   "scripts": {

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -118,9 +118,20 @@ export default class ImageZoom extends Component {
       onClick: this.handleZoom
     })
 
-    return (
-      <img { ...attrs } />
+    const image = (
+      <img ref="image" { ...attrs } />
     )
+
+    if (this.props.shouldPreload && this.props.zoomImage && this.props.zoomImage.src) {
+      return (
+        <span>
+          <link rel="preload" href={this.props.zoomImage.src} as="image" />
+          { image }
+        </span>
+      )
+    }
+
+    return image
   }
 
   // Side-effects!
@@ -129,7 +140,7 @@ export default class ImageZoom extends Component {
     this.portalInstance = ReactDOM.render(
       <Zoom
         { ...this.props.zoomImage }
-        image={ ReactDOM.findDOMNode(this) }
+        image={ ReactDOM.findDOMNode(this.refs.image) }
         defaultStyles={ this.props.defaultStyles }
         hasAlreadyLoaded={ this.state.hasAlreadyLoaded }
         shouldRespectMaxDimension={ this.props.shouldRespectMaxDimension }
@@ -214,9 +225,10 @@ ImageZoom.propTypes = {
   }),
   defaultStyles: object,
   isZoomed: bool,
+  shouldHandleZoom: func,
+  shouldPreload: bool,
   shouldReplaceImage: bool,
   shouldRespectMaxDimension: bool,
-  shouldHandleZoom: func,
   onZoom: func,
   onUnzoom: func
 }


### PR DESCRIPTION
GH Issue: https://github.com/rpearce/react-medium-image-zoom/issues/35

tl;dr => When `true` and `zoomImage` is included, preload the `zoomImage.src` by including a `<link rel="preload">` for image's source

The original request asked for the link to be included in the `<head>`, but I think this becomes problematic because we're now manipulating the head tag of a page when all we really need to do is do it inline, which still allows for cleanup.

Discussion welcomed either here or on https://github.com/rpearce/react-medium-image-zoom/issues/35.