### PR TITLE
Add srcset support and pass all props to zoomImage

### DIFF
--- a/example/build/app.js
+++ b/example/build/app.js
@@ -534,7 +534,6 @@ var Zoom = function (_Component2) {
     value: function render() {
       var _props2 = this.props,
           defaultStyles = _props2.defaultStyles,
-          hasAlreadyLoaded = _props2.hasAlreadyLoaded,
           zoomImage = _props2.zoomImage;
       var _state = this.state,
           isZoomed = _state.isZoomed,

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -274,7 +274,7 @@ class Zoom extends Component {
   }
 
   render() {
-    const { defaultStyles, hasAlreadyLoaded, zoomImage } = this.props
+    const { defaultStyles, zoomImage } = this.props
     const { isZoomed, src } = this.state
 
     return (

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -286,7 +286,6 @@ class Zoom extends Component {
         <img
           { ...zoomImage }
           src={ src }
-          srcSet={ hasAlreadyLoaded ? zoomImage.srcSet : null }
           style={ this.getZoomImageStyle() }
         />
       </div>
@@ -306,8 +305,8 @@ class Zoom extends Component {
     const img = new Image()
 
     img.src = src
-    img.srcset = srcSet
-    img.sizes = sizes
+    if (srcSet) img.srcset = srcSet
+    if (sizes) img.sizes = sizes
 
     const onLoad = () => {
       // Only set state if component is still mounted

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -268,16 +268,19 @@ class Zoom extends Component {
   }
 
   render() {
+    const { defaultStyles, hasAlreadyLoaded, zoomImage } = this.props
+    const { isZoomed, src } = this.state
+
     return (
       <div onClick={ this.handleUnzoom } style={ this.getZoomContainerStyle() }>
         <Overlay
-          isVisible={ this.state.isZoomed }
-          defaultStyles={ this.props.defaultStyles }
+          isVisible={ isZoomed }
+          defaultStyles={ defaultStyles }
         />
         <img
-          { ...this.props.zoomImage }
-          src={ this.state.src }
-          srcSet={ this.state.srcSet }
+          { ...zoomImage }
+          src={ src }
+          srcSet={ hasAlreadyLoaded ? zoomImage.srcSet : null }
           style={ this.getZoomImageStyle() }
         />
       </div>
@@ -303,7 +306,7 @@ class Zoom extends Component {
     const onLoad = () => {
       // Only set state if component is still mounted
       if (this.state.isZoomed) {
-        this.setState({ hasLoaded: true, src, srcSet })
+        this.setState({ hasLoaded: true, src: img.currentSrc || img.src })
       }
 
       /**

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -255,6 +255,12 @@ class Zoom extends Component {
     this.handleTouchEnd   = this.handleTouchEnd.bind(this)
   }
 
+  static get defaultProps() {
+    return {
+      zoomImage: {},
+    }
+  }
+
   componentDidMount() {
     const { hasAlreadyLoaded, zoomImage: { src, srcSet } } = this.props
 


### PR DESCRIPTION
This PR addresses issue #42.

All props are now passed down to the `Zoom` img component, with special cases for src, srcset, and style.

One note/question: the `hasLoaded` state on the Zoom component is being set in two places
https://github.com/rpearce/react-medium-image-zoom/blob/master/src/react-medium-image-zoom.js#L259
https://github.com/rpearce/react-medium-image-zoom/blob/master/src/react-medium-image-zoom.js#L297

Maybe I'm missing something, but they seem to each reference a difference load event - one being the component mounting, the other being the img element loading. Is this right?