### PR TITLE
Fix isZoomed check in componentWillReceiveProps

### DIFF
--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -87,7 +87,7 @@ export default class ImageZoom extends Component {
    */
   componentWillReceiveProps(nextProps) {
     const imageChanged = this.props.image.src !== nextProps.image.src
-    const isZoomedChanged = this.state.isZoomed !== nextProps.isZoomed
+    const isZoomedChanged = this.props.isZoomed !== nextProps.isZoomed
     const changes = Object.assign({},
       imageChanged && { image: nextProps.image },
       isZoomedChanged && { isZoomed : nextProps.isZoomed }


### PR DESCRIPTION
Should be checking this.props against nextProps to see if props have
updated. Was instead checking against .state which could be different
even if isZoomed prop never changed.

To reproduce the issue I'm seeing, setting a prop to change after 10 seconds and then zoom into an image. Even though the prop you change isn't `isZoomed` the image will unzoom.