### PR TITLE
Remove preload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ function MyComponent(props) {
 | `zoomMargin`                | number  | no       | `40`    | Pixel number to offset zoomed image from the window |
 | `isZoomed`                  | boolean | no       | `false` | For more direct control over the zoom state |
 | `shouldHandleZoom`          | func    | no       | `(event) => true` | Pass this callback to intercept a zoom click event and determine whether or not to zoom. Function must return a truthy or falsy value |
-| `shouldPreload`             | bool    | no       | `false` | When `true` and `zoomImage` is included, preload the `zoomImage.src` by including a `<link rel="preload">` for image's source |
 | `shouldReplaceImage`        | boolean | no       | `true`  | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
 | `shouldRespectMaxDimension` | boolean | no       | `false` | When `true`, don't make the zoomed image's dimensions larger than the original dimensions. _Currently only supported when NO zoomImage is provided._  |
 | `defaultStyles`             | object  | no       | `{}` | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |

--- a/example/build/app.js
+++ b/example/build/app.js
@@ -94,8 +94,7 @@ var App = function (_Component) {
               alt: 'Golden Gate Bridge',
               className: 'img--zoomed'
             },
-            isZoomed: this.state.firstActive,
-            shouldPreload: true
+            isZoomed: this.state.firstActive
           })
         ),
         _react2.default.createElement(
@@ -352,13 +351,7 @@ var ImageZoom = function (_Component) {
         onClick: this.handleZoom
       });
 
-      var image = _react2.default.createElement('img', _extends({ ref: 'image' }, attrs));
-
-      if (this.props.shouldPreload && this.props.zoomImage && this.props.zoomImage.src) {
-        return _react2.default.createElement('span', null, _react2.default.createElement('link', { rel: 'preload', href: this.props.zoomImage.src, as: 'image' }), image);
-      }
-
-      return image;
+      return _react2.default.createElement('img', _extends({ ref: 'image' }, attrs));
     }
 
     // Side-effects!
@@ -478,7 +471,6 @@ ImageZoom.propTypes = {
   defaultStyles: object,
   isZoomed: bool,
   shouldHandleZoom: func,
-  shouldPreload: bool,
   shouldReplaceImage: bool,
   shouldRespectMaxDimension: bool,
   onZoom: func,

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -50,7 +50,6 @@ class App extends Component {
               className: 'img--zoomed'
             }}
             isZoomed={ this.state.firstActive }
-            shouldPreload={true}
           />
         </div>
         <p>Thundercats freegan Truffaut, four loko twee Austin scenester lo-fi seitan High Life paleo quinoa cray. Schlitz butcher ethical Tumblr, pop-up DIY keytar ethnic iPhone PBR sriracha. Tonx direct trade bicycle rights gluten-free flexitarian asymmetrical. Whatever drinking vinegar PBR XOXO Bushwick gentrify. Cliche semiotics banjo retro squid Wes Anderson. Fashion axe dreamcatcher you probably haven't heard of them bicycle rights. Tote bag organic four loko ethical selfies gastropub, PBR fingerstache tattooed bicycle rights.</p>

--- a/src/react-medium-image-zoom.js
+++ b/src/react-medium-image-zoom.js
@@ -119,20 +119,7 @@ export default class ImageZoom extends Component {
       onClick: this.handleZoom
     })
 
-    const image = (
-      <img ref="image" { ...attrs } />
-    )
-
-    if (this.props.shouldPreload && this.props.zoomImage && this.props.zoomImage.src) {
-      return (
-        <span>
-          <link rel="preload" href={this.props.zoomImage.src} as="image" />
-          { image }
-        </span>
-      )
-    }
-
-    return image
+    return <img ref="image" { ...attrs } />
   }
 
   // Side-effects!
@@ -227,7 +214,6 @@ ImageZoom.propTypes = {
   defaultStyles: object,
   isZoomed: bool,
   shouldHandleZoom: func,
-  shouldPreload: bool,
   shouldReplaceImage: bool,
   shouldRespectMaxDimension: bool,
   onZoom: func,


### PR DESCRIPTION
I think the preload functionality can and should be handled by the package consumer and not by this package. It should be easy enough to recreate this functionality:

```js
<span>
  <link rel="preload" href={...} as="image" />
  <ImageZoom ... />
</span>
```

This'll be included in the v2.0 release.

cc @ismay for review