### PR TITLE
Don't provide zoom option if it can't actually be zoomed

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,12 @@
-.babelrc
+.storybook/
 example/
 src/
+stories/
+.all-contributorsrc
+.babelrc
+*.md
+.eslintignore
+.eslintrc
+.prettierignore
+.prettierrc
+nodemon.json

--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ function MyComponent(props) {
 }
 ```
 
-| Prop                        | Type    | Required | Default | Details |
-| ------                      | ------- | -------  | ------- | ------- |
-| `image`                     | object  | yes      | none    | The original image |
-| `zoomImage`                 | object  | no       | `image` | The image to be used for zooming |
-| `zoomMargin`                | number  | no       | `40`    | Pixel number to offset zoomed image from the window |
-| `isZoomed`                  | boolean | no       | `false` | For more direct control over the zoom state |
-| `shouldHandleZoom`          | func    | no       | `(event) => true` | Pass this callback to intercept a zoom click event and determine whether or not to zoom. Function must return a truthy or falsy value |
-| `shouldReplaceImage`        | boolean | no       | `true`  | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
-| `shouldRespectMaxDimension` | boolean | no       | `false` | When `true`, don't make the zoomed image's dimensions larger than the original dimensions. _Currently only supported when NO zoomImage is provided._  |
-| `defaultStyles`             | object  | no       | `{}` | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |
-| `onZoom`                    | func    | no       | `() => {}` | Pass this callback to respond to a zoom interaction. |
-| `onUnzoom`                  | func    | no       | `() => {}` | Pass this callback to respond to an unzoom interaction. |
+| Prop                          | Type    | Required | Default           | Details |
+| ---                           | ---     | ---      | ---               | ---     |
+| `image`                       | object  | yes      | none              | The original image |
+| `zoomImage`                   | object  | no       | `image`           | The image to be used for zooming |
+| `zoomMargin`                  | number  | no       | `40`              | Pixel number to offset zoomed image from the window |
+| `isZoomed`                    | boolean | no       | `false`           | For more direct control over the zoom state |
+| `shouldHandleZoom`            | func    | no       | `(event) => true` | Pass this callback to intercept a zoom click event and determine whether or not to zoom. Function must return a truthy or falsy value |
+| `shouldReplaceImage`          | boolean | no       | `true`            | Once the image has been "zoomed" and downloaded the larger image, this replaces the original `image` with the `zoomImage` |
+| `shouldRespectMaxDimension`   | boolean | no       | `false`           | When `true`, don't make the zoomed image's dimensions larger than the original dimensions. Only supported if no `zoomImage` is provided. Will also disable the zooming if the image's is already rendered at its maximum width & height |
+| `defaultStyles`               | object  | no       | `{}`              | For fine-grained control over all default styles (`zoomContainer`, `overlay`, `image`, `zoomImage`) |
+| `onZoom`                      | func    | no       | `() => {}`        | Pass this callback to respond to a zoom interaction. |
+| `onUnzoom`                    | func    | no       | `() => {}`        | Pass this callback to respond to an unzoom interaction. |
 
 Each one of these image props accepts normal `image` props, for example:
 

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -107,7 +107,7 @@ class App extends Component {
               title: "Don't exceed original image dimensions...",
               className: 'img',
               style: {
-                width: '80%'
+                width: '250px'
               }
             }}
             shouldRespectMaxDimension={true}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Medium.com style image zoom for React",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,9 +48,15 @@ export const getMaxDimensionScale = ({
   naturalHeight,
   zoomMargin
 }) => {
-  const scale = getScale({ width: naturalWidth, height: naturalHeight, zoomMargin })
-  const ratio = naturalWidth > naturalHeight
-    ? naturalWidth / width
-    : naturalHeight / height
+  const scale = getScale({
+    width: naturalWidth,
+    height: naturalHeight,
+    zoomMargin
+  })
+  const ratio =
+    naturalWidth > naturalHeight ? naturalWidth / width : naturalHeight / height
   return scale > 1 ? ratio : scale * ratio
 }
+
+export const isMaxDimension = img =>
+  img.clientWidth >= img.naturalWidth || img.clientHeight >= img.naturalHeight

--- a/stories/DefaultStyles.js
+++ b/stories/DefaultStyles.js
@@ -12,18 +12,6 @@ const DefaultStyles = () =>
     </p>
     <hr />
     <p>
-      Trust fund seitan chia, wolf lomo letterpress Bushwick before they sold
-      out. Carles kogi fixie, squid twee Tonx readymade cred typewriter
-      scenester locavore kale chips vegan organic. Meggings pug wolf Shoreditch
-      typewriter skateboard. McSweeney&apos;s iPhone chillwave, food truck
-      direct trade disrupt flannel irony tousled Cosby sweater single-origin
-      coffee. Organic disrupt bicycle rights, tattooed messenger bag flannel
-      craft beer fashion axe bitters. Readymade sartorial craft beer, quinoa
-      sustainable butcher Marfa Echo Park Terry Richardson gluten-free flannel
-      retro cred mlkshk banjo. Salvia 90&apos;s art party Blue Bottle, PBR&amp;B
-      cardigan 8-bit.
-    </p>
-    <p>
       <ImageZoom
         image={{
           src: 'https://rpearce.github.io/react-medium-image-zoom/bridge.jpg',
@@ -44,40 +32,6 @@ const DefaultStyles = () =>
           }
         }}
       />
-    </p>
-    <p>
-      Meggings irony fashion axe, tattooed master cleanse Blue Bottle stumptown
-      bitters authentic flannel freegan paleo letterpress ugh sriracha. Wolf
-      PBR&amp;B art party aesthetic meh cliche. Sartorial before they sold out
-      deep v, aesthetic PBR&amp;B craft beer post-ironic synth keytar pork belly
-      skateboard pour-over. Tonx cray pug Etsy, gastropub ennui wolf ethnic Odd
-      Future viral master cleanse skateboard banjo. Pitchfork scenester
-      cornhole, whatever try-hard ethnic banjo +1 gastropub American Apparel
-      vinyl skateboard Shoreditch seitan. Blue Bottle keffiyeh Austin Helvetica
-      art party. Portland ethnic fixie, beard retro direct trade ugh scenester
-      Tumblr readymade authentic plaid pickled hashtag biodiesel.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
     </p>
   </div>
 

--- a/stories/ShouldHandleZoom.js
+++ b/stories/ShouldHandleZoom.js
@@ -43,18 +43,6 @@ const ShouldHandleZoom = ({ isEnabled, onToggle }) =>
     </p>
     <hr />
     <p>
-      Trust fund seitan chia, wolf lomo letterpress Bushwick before they sold
-      out. Carles kogi fixie, squid twee Tonx readymade cred typewriter
-      scenester locavore kale chips vegan organic. Meggings pug wolf Shoreditch
-      typewriter skateboard. McSweeney&apos;s iPhone chillwave, food truck
-      direct trade disrupt flannel irony tousled Cosby sweater single-origin
-      coffee. Organic disrupt bicycle rights, tattooed messenger bag flannel
-      craft beer fashion axe bitters. Readymade sartorial craft beer, quinoa
-      sustainable butcher Marfa Echo Park Terry Richardson gluten-free flannel
-      retro cred mlkshk banjo. Salvia 90&apos;s art party Blue Bottle, PBR&amp;B
-      cardigan 8-bit.
-    </p>
-    <p>
       <ImageZoom
         image={{
           src: 'https://rpearce.github.io/react-medium-image-zoom/bridge.jpg',
@@ -65,40 +53,6 @@ const ShouldHandleZoom = ({ isEnabled, onToggle }) =>
         }}
         shouldHandleZoom={() => isEnabled}
       />
-    </p>
-    <p>
-      Meggings irony fashion axe, tattooed master cleanse Blue Bottle stumptown
-      bitters authentic flannel freegan paleo letterpress ugh sriracha. Wolf
-      PBR&amp;B art party aesthetic meh cliche. Sartorial before they sold out
-      deep v, aesthetic PBR&amp;B craft beer post-ironic synth keytar pork belly
-      skateboard pour-over. Tonx cray pug Etsy, gastropub ennui wolf ethnic Odd
-      Future viral master cleanse skateboard banjo. Pitchfork scenester
-      cornhole, whatever try-hard ethnic banjo +1 gastropub American Apparel
-      vinyl skateboard Shoreditch seitan. Blue Bottle keffiyeh Austin Helvetica
-      art party. Portland ethnic fixie, beard retro direct trade ugh scenester
-      Tumblr readymade authentic plaid pickled hashtag biodiesel.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
     </p>
   </div>
 

--- a/stories/ShouldReplaceImage.js
+++ b/stories/ShouldReplaceImage.js
@@ -11,18 +11,6 @@ const ShouldReplaceImage = () =>
     </p>
     <hr />
     <p>
-      Trust fund seitan chia, wolf lomo letterpress Bushwick before they sold
-      out. Carles kogi fixie, squid twee Tonx readymade cred typewriter
-      scenester locavore kale chips vegan organic. Meggings pug wolf Shoreditch
-      typewriter skateboard. McSweeney&apos;s iPhone chillwave, food truck
-      direct trade disrupt flannel irony tousled Cosby sweater single-origin
-      coffee. Organic disrupt bicycle rights, tattooed messenger bag flannel
-      craft beer fashion axe bitters. Readymade sartorial craft beer, quinoa
-      sustainable butcher Marfa Echo Park Terry Richardson gluten-free flannel
-      retro cred mlkshk banjo. Salvia 90&apos;s art party Blue Bottle, PBR&amp;B
-      cardigan 8-bit.
-    </p>
-    <p>
       <ImageZoom
         image={{
           src: 'https://rpearce.github.io/react-medium-image-zoom/bridge.jpg',
@@ -38,40 +26,6 @@ const ShouldReplaceImage = () =>
         }}
         shouldReplaceImage={false}
       />
-    </p>
-    <p>
-      Meggings irony fashion axe, tattooed master cleanse Blue Bottle stumptown
-      bitters authentic flannel freegan paleo letterpress ugh sriracha. Wolf
-      PBR&amp;B art party aesthetic meh cliche. Sartorial before they sold out
-      deep v, aesthetic PBR&amp;B craft beer post-ironic synth keytar pork belly
-      skateboard pour-over. Tonx cray pug Etsy, gastropub ennui wolf ethnic Odd
-      Future viral master cleanse skateboard banjo. Pitchfork scenester
-      cornhole, whatever try-hard ethnic banjo +1 gastropub American Apparel
-      vinyl skateboard Shoreditch seitan. Blue Bottle keffiyeh Austin Helvetica
-      art party. Portland ethnic fixie, beard retro direct trade ugh scenester
-      Tumblr readymade authentic plaid pickled hashtag biodiesel.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
     </p>
   </div>
 

--- a/stories/ShouldRespectMaxDimension.js
+++ b/stories/ShouldRespectMaxDimension.js
@@ -16,19 +16,13 @@ const ShouldRespectMaxDimension = () =>
       normal border offset (unless you&apos;re on a smaller screen than a
       Macbook Pro).
     </p>
-    <hr />
     <p>
-      Trust fund seitan chia, wolf lomo letterpress Bushwick before they sold
-      out. Carles kogi fixie, squid twee Tonx readymade cred typewriter
-      scenester locavore kale chips vegan organic. Meggings pug wolf Shoreditch
-      typewriter skateboard. McSweeney&apos;s iPhone chillwave, food truck
-      direct trade disrupt flannel irony tousled Cosby sweater single-origin
-      coffee. Organic disrupt bicycle rights, tattooed messenger bag flannel
-      craft beer fashion axe bitters. Readymade sartorial craft beer, quinoa
-      sustainable butcher Marfa Echo Park Terry Richardson gluten-free flannel
-      retro cred mlkshk banjo. Salvia 90&apos;s art party Blue Bottle, PBR&amp;B
-      cardigan 8-bit.
+      Note: if an image is already at its maximum width &amp; height and no
+      zoomImage is provided, it will disable all functionality (including
+      cursor).
     </p>
+    <hr />
+    <h2>Don&apos;t exceed original image dimensions</h2>
     <p>
       <ImageZoom
         image={{
@@ -36,56 +30,24 @@ const ShouldRespectMaxDimension = () =>
           alt: 'Gazelle Stomping',
           title: "Don't exceed original image dimensions...",
           style: {
-            width: '200px'
+            width: '250px'
           }
         }}
         shouldRespectMaxDimension={true}
       />
     </p>
+    <h2>Disable component if image is already at its max dimensions</h2>
     <p>
-      Meggings irony fashion axe, tattooed master cleanse Blue Bottle stumptown
-      bitters authentic flannel freegan paleo letterpress ugh sriracha. Wolf
-      PBR&amp;B art party aesthetic meh cliche. Sartorial before they sold out
-      deep v, aesthetic PBR&amp;B craft beer post-ironic synth keytar pork belly
-      skateboard pour-over. Tonx cray pug Etsy, gastropub ennui wolf ethnic Odd
-      Future viral master cleanse skateboard banjo. Pitchfork scenester
-      cornhole, whatever try-hard ethnic banjo +1 gastropub American Apparel
-      vinyl skateboard Shoreditch seitan. Blue Bottle keffiyeh Austin Helvetica
-      art party. Portland ethnic fixie, beard retro direct trade ugh scenester
-      Tumblr readymade authentic plaid pickled hashtag biodiesel.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
+      <ImageZoom
+        image={{
+          src:
+            'https://user-images.githubusercontent.com/592876/30724341-68df3036-9f91-11e7-9741-2f0aaa7d9df7.jpg',
+          alt:
+            'Puppy licking hand – https://www.instagram.com/p/BReegO8Bf0w/?taken-by=raleigh_thelabpup',
+          title: 'Disable library if image is already max'
+        }}
+        shouldRespectMaxDimension={true}
+      />
     </p>
   </div>
 

--- a/stories/ZoomImage.js
+++ b/stories/ZoomImage.js
@@ -18,18 +18,6 @@ const ZoomImage = () =>
     </p>
     <hr />
     <p>
-      Trust fund seitan chia, wolf lomo letterpress Bushwick before they sold
-      out. Carles kogi fixie, squid twee Tonx readymade cred typewriter
-      scenester locavore kale chips vegan organic. Meggings pug wolf Shoreditch
-      typewriter skateboard. McSweeney&apos;s iPhone chillwave, food truck
-      direct trade disrupt flannel irony tousled Cosby sweater single-origin
-      coffee. Organic disrupt bicycle rights, tattooed messenger bag flannel
-      craft beer fashion axe bitters. Readymade sartorial craft beer, quinoa
-      sustainable butcher Marfa Echo Park Terry Richardson gluten-free flannel
-      retro cred mlkshk banjo. Salvia 90&apos;s art party Blue Bottle, PBR&amp;B
-      cardigan 8-bit.
-    </p>
-    <p>
       <ImageZoom
         image={{
           src: 'https://rpearce.github.io/react-medium-image-zoom/bridge.jpg',
@@ -44,40 +32,6 @@ const ZoomImage = () =>
           alt: 'Golden Gate Bridge'
         }}
       />
-    </p>
-    <p>
-      Meggings irony fashion axe, tattooed master cleanse Blue Bottle stumptown
-      bitters authentic flannel freegan paleo letterpress ugh sriracha. Wolf
-      PBR&amp;B art party aesthetic meh cliche. Sartorial before they sold out
-      deep v, aesthetic PBR&amp;B craft beer post-ironic synth keytar pork belly
-      skateboard pour-over. Tonx cray pug Etsy, gastropub ennui wolf ethnic Odd
-      Future viral master cleanse skateboard banjo. Pitchfork scenester
-      cornhole, whatever try-hard ethnic banjo +1 gastropub American Apparel
-      vinyl skateboard Shoreditch seitan. Blue Bottle keffiyeh Austin Helvetica
-      art party. Portland ethnic fixie, beard retro direct trade ugh scenester
-      Tumblr readymade authentic plaid pickled hashtag biodiesel.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
-    </p>
-    <p>
-      Scenester chambray slow-carb, trust fund biodiesel ugh bicycle rights
-      cornhole. Gentrify messenger bag Truffaut tousled roof party pork belly
-      leggings, photo booth jean shorts. Austin readymade PBR plaid chambray.
-      Squid Echo Park pour-over, wayfarers forage whatever locavore typewriter
-      artisan deep v four loko. Locavore occupy Neutra Pitchfork
-      McSweeney&apos;s, wayfarers fingerstache. Actually asymmetrical drinking
-      vinegar yr brunch biodiesel. Before they sold out sustainable readymade
-      craft beer Portland gastropub squid Austin, roof party Thundercats
-      chambray narwhal Bushwick pug.
     </p>
   </div>
 


### PR DESCRIPTION
Fixes #54 

I've classified this as a bug. If you pass `shouldRespectMaxDimension={true}`, then that specification should include the following:

* if the image rendered on the screen is the largest version of the image that we're going to get, then don't bother showing any zooming capabilities, as the alternative is just moving the exact same image to the center of the screen .

* * *

This PR also adds a number of unnecessary files to the `.npmignore` and updates the storybook.