### PR TITLE
Image attribute mutability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,8 @@
     "array-bracket-spacing": ["error", "always"],
     "camelcase": "error",
     "global-require": "error",
+    "no-console": "warn",
+    "no-debugger": "warn",
     "no-duplicate-imports": "error",
     "no-eq-null": "error",
     "no-extra-parens": "error",

--- a/example/build/app.js
+++ b/example/build/app.js
@@ -424,7 +424,7 @@ var ImageZoom = function (_Component) {
     _this.state = {
       isMaxDimension: false,
       isZoomed: false,
-      image: props.image,
+      src: props.image.src,
       hasAlreadyLoaded: false
     };
 
@@ -474,9 +474,13 @@ var ImageZoom = function (_Component) {
         this.isClosing = true;
       }
 
+      var src = this.props.image.src;
+      var nextSrc = nextProps.image.src;
+
       // If the consumer wants to change the image's src, then so be it.
-      if (this.props.image.src !== nextProps.image.src) {
-        this.setState({ image: nextProps.image });
+
+      if (src !== nextSrc) {
+        this.setState({ src: nextSrc });
       }
     }
 
@@ -506,18 +510,21 @@ var ImageZoom = function (_Component) {
     value: function render() {
       var _this2 = this;
 
+      var image = this.props.image;
       var _state = this.state,
-          image = _state.image,
-          isMaxDimension = _state.isMaxDimension;
+          isMaxDimension = _state.isMaxDimension,
+          src = _state.src;
 
       /**
        * Take whatever attributes you want to pass the image
-       * and then override with the properties we need.
+       * and then override with the properties we need,
+       * including using state as source of truth for hi/low-res 
+       * version img src.
        * Also, disable any clicking if the component is
        * already at its maximum dimensions.
        */
 
-      var attrs = _extends({}, !isMaxDimension && { tabIndex: focusableTabIndex }, image, { style: this._getImageStyle() }, !isMaxDimension && {
+      var attrs = _extends({}, !isMaxDimension && { tabIndex: focusableTabIndex }, image, { src: src, style: this._getImageStyle() }, !isMaxDimension && {
         onClick: this._handleZoom,
         onKeyDown: this._handleKeyDown
       });
@@ -579,7 +586,7 @@ var ImageZoom = function (_Component) {
       var isHidden = this.state.isZoomed || this.props.isZoomed || this.isClosing;
       var style = _extends({}, isHidden && { visibility: 'hidden' });
 
-      return _extends({}, _defaults2.default.styles.image, style, this.props.defaultStyles.image, this.state.image.style, this.state.isMaxDimension && { cursor: 'inherit' });
+      return _extends({}, _defaults2.default.styles.image, style, this.props.defaultStyles.image, this.props.image.style, this.state.isMaxDimension && { cursor: 'inherit' });
     }
 
     /**
@@ -626,9 +633,7 @@ var ImageZoom = function (_Component) {
       var _this3 = this;
 
       return function () {
-        var changes = _extends({}, { hasAlreadyLoaded: true, isZoomed: false }, _this3.props.shouldReplaceImage && {
-          image: _extends({}, _this3.state.image, { src: src })
-        });
+        var changes = _extends({}, { hasAlreadyLoaded: true, isZoomed: false }, _this3.props.shouldReplaceImage && { src: src });
 
         /**
          * Lamentable but necessary right now in order to
@@ -2112,18 +2117,11 @@ module.exports = factory;
 
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @typechecks
  */
@@ -3179,45 +3177,43 @@ var emptyFunction = require('./emptyFunction');
 var warning = emptyFunction;
 
 if (process.env.NODE_ENV !== 'production') {
-  (function () {
-    var printWarning = function printWarning(format) {
-      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-        args[_key - 1] = arguments[_key];
+  var printWarning = function printWarning(format) {
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var argIndex = 0;
+    var message = 'Warning: ' + format.replace(/%s/g, function () {
+      return args[argIndex++];
+    });
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+
+  warning = function warning(condition, format) {
+    if (format === undefined) {
+      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+    }
+
+    if (format.indexOf('Failed Composite propType: ') === 0) {
+      return; // Ignore CompositeComponent proptype check.
+    }
+
+    if (!condition) {
+      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+        args[_key2 - 2] = arguments[_key2];
       }
 
-      var argIndex = 0;
-      var message = 'Warning: ' + format.replace(/%s/g, function () {
-        return args[argIndex++];
-      });
-      if (typeof console !== 'undefined') {
-        console.error(message);
-      }
-      try {
-        // --- Welcome to debugging React ---
-        // This error was thrown as a convenience so that you can use this stack
-        // to find the callsite that caused this warning to fire.
-        throw new Error(message);
-      } catch (x) {}
-    };
-
-    warning = function warning(condition, format) {
-      if (format === undefined) {
-        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
-      }
-
-      if (format.indexOf('Failed Composite propType: ') === 0) {
-        return; // Ignore CompositeComponent proptype check.
-      }
-
-      if (!condition) {
-        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
-          args[_key2 - 2] = arguments[_key2];
-        }
-
-        printWarning.apply(undefined, [format].concat(args));
-      }
-    };
-  })();
+      printWarning.apply(undefined, [format].concat(args));
+    }
+  };
 }
 
 module.exports = warning;
@@ -3485,6 +3481,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');

--- a/src/ImageZoom.js
+++ b/src/ImageZoom.js
@@ -19,7 +19,7 @@ export default class ImageZoom extends Component {
     this.state = {
       isMaxDimension: false,
       isZoomed: false,
-      image: props.image,
+      src: props.image.src,
       hasAlreadyLoaded: false
     }
 
@@ -85,9 +85,12 @@ export default class ImageZoom extends Component {
       this.isClosing = true
     }
 
+    const { src } = this.props.image
+    const { src: nextSrc } = nextProps.image
+
     // If the consumer wants to change the image's src, then so be it.
-    if (this.props.image.src !== nextProps.image.src) {
-      this.setState({ image: nextProps.image })
+    if (src !== nextSrc) {
+      this.setState({ src: nextSrc })
     }
   }
 
@@ -115,11 +118,14 @@ export default class ImageZoom extends Component {
   }
 
   render() {
-    const { image, isMaxDimension } = this.state
+    const { image } = this.props
+    const { isMaxDimension, src } = this.state
 
     /**
      * Take whatever attributes you want to pass the image
-     * and then override with the properties we need.
+     * and then override with the properties we need,
+     * including using state as source of truth for hi/low-res 
+     * version img src.
      * Also, disable any clicking if the component is
      * already at its maximum dimensions.
      */
@@ -127,7 +133,7 @@ export default class ImageZoom extends Component {
       {},
       !isMaxDimension && { tabIndex: focusableTabIndex },
       image,
-      { style: this._getImageStyle() },
+      { src, style: this._getImageStyle() },
       !isMaxDimension && {
         onClick: this._handleZoom,
         onKeyDown: this._handleKeyDown
@@ -202,7 +208,7 @@ export default class ImageZoom extends Component {
       defaults.styles.image,
       style,
       this.props.defaultStyles.image,
-      this.state.image.style,
+      this.props.image.style,
       this.state.isMaxDimension && { cursor: 'inherit' }
     )
   }
@@ -247,9 +253,7 @@ export default class ImageZoom extends Component {
       const changes = Object.assign(
         {},
         { hasAlreadyLoaded: true, isZoomed: false },
-        this.props.shouldReplaceImage && {
-          image: Object.assign({}, this.state.image, { src })
-        }
+        this.props.shouldReplaceImage && { src }
       )
 
       /**

--- a/stories/ShouldRespectTabIndex.js
+++ b/stories/ShouldRespectTabIndex.js
@@ -1,5 +1,71 @@
-import React from 'react'
+import React, { Component } from 'react'
 import ImageZoom from '../src'
+
+export default class Container extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isFocusEnabled: false
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <ShouldRespectTabIndex />
+        <ShouldRespectAttributeChange
+          isFocusEnabled={this.state.isFocusEnabled}
+          onToggle={() =>
+            this.setState({ isFocusEnabled: !this.state.isFocusEnabled })}
+        />
+      </div>
+    )
+  }
+}
+
+const ShouldRespectAttributeChange = ({ isFocusEnabled, onToggle }) => {
+  const tabIndex = isFocusEnabled ? 0 : -1
+  return (
+    <div>
+      <h1>
+        Conditionally allow/disallow keyboard interaction for accessibility
+      </h1>
+      <p>
+        There are instances where you might want to conditionally enable or
+        disable the ability to zoom an image dynamically. You can specify -1 for
+        the image element tabIndex attribute to disable focus/interaction and 0
+        to enable focus/interaction.
+      </p>
+      <p>
+        Try it! Click this checkbox to enable keyboard interaction and uncheck
+        it to disable keyboard interaction.
+      </p>
+      <p>
+        <input
+          type="checkbox"
+          value={isFocusEnabled}
+          checked={isFocusEnabled}
+          onChange={onToggle}
+          id="enable"
+        />
+        <label htmlFor="enable">Enable Keyboard Interaction</label>
+      </p>
+      <hr />
+      <p>
+        <ImageZoom
+          image={{
+            src: 'https://rpearce.github.io/react-medium-image-zoom/bridge.jpg',
+            alt: 'Golden Gate Bridge',
+            style: {
+              width: '300px'
+            },
+            tabIndex
+          }}
+        />
+      </p>
+    </div>
+  )
+}
 
 const ShouldRespectTabIndex = () =>
   <div>
@@ -43,5 +109,3 @@ const ShouldRespectTabIndex = () =>
     </p>
   </div>
 
-
-export default ShouldRespectTabIndex


### PR DESCRIPTION
Fixes #77 

* These changes isolate cached state to image `src` (required to support high/low-res versions), allowing all other image attributes (`alt`, `className`, `tabIndex`, etc) to change without also first changing the image source. 
* Bonus fixed subtle issue with unzoomable images being able to receive keyboard focus.
* Relaxed a couple of the lint errors to warnings to make debugging easier. 