### PR TITLE
Tab Trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.7] - 2017-12-05
+
+### Fixed
+- Fixed issue where hitting the tab key on a zoomed imaged would allow
+an element in behind the image to receive focus. Further actions
+could then be taken on the focused element, causing the DOM to end
+up in undesired states.
+
 ## [2.0.6] - 2017-11-02
 
 ### Fixed

--- a/example/build/app.js
+++ b/example/build/app.js
@@ -270,6 +270,11 @@ var EventsWrapper = function (_Component) {
   }, {
     key: '_handleKeyDown',
     value: function _handleKeyDown(e) {
+      if ((0, _keyboardEvents.isTabKey)(e)) {
+        e.preventDefault(); // prevent in-behind controls from grabbing focus
+        return;
+      }
+
       var allowAccessibilityClose = this.props.allowAccessibilityClose;
 
       var unzoomForEnterOrSpace = allowAccessibilityClose && (0, _keyboardEvents.isEnterOrSpaceBarKey)(e);
@@ -1195,6 +1200,11 @@ var enterKey = {
   keyCode: 13
 };
 
+var tabKey = {
+  keys: ['Tab'],
+  keyCode: 9
+};
+
 var spaceBarKey = {
   keys: [' '],
   keyCode: 32
@@ -1234,6 +1244,7 @@ var escapeKey = {
 var isEnterOrSpaceBarKey = exports.isEnterOrSpaceBarKey = function isEnterOrSpaceBarKey(e) {
   return isKey(enterKey)(e) || isSpaceBarKey(e);
 };
+var isTabKey = exports.isTabKey = isKey(tabKey);
 var isSpaceBarKey = exports.isSpaceBarKey = isKey(spaceBarKey);
 var isEscapeKey = exports.isEscapeKey = isKey(escapeKey);
 
@@ -2119,18 +2130,11 @@ module.exports = factory;
 
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @typechecks
  */
@@ -3186,45 +3190,43 @@ var emptyFunction = require('./emptyFunction');
 var warning = emptyFunction;
 
 if (process.env.NODE_ENV !== 'production') {
-  (function () {
-    var printWarning = function printWarning(format) {
-      for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-        args[_key - 1] = arguments[_key];
+  var printWarning = function printWarning(format) {
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var argIndex = 0;
+    var message = 'Warning: ' + format.replace(/%s/g, function () {
+      return args[argIndex++];
+    });
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+
+  warning = function warning(condition, format) {
+    if (format === undefined) {
+      throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
+    }
+
+    if (format.indexOf('Failed Composite propType: ') === 0) {
+      return; // Ignore CompositeComponent proptype check.
+    }
+
+    if (!condition) {
+      for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
+        args[_key2 - 2] = arguments[_key2];
       }
 
-      var argIndex = 0;
-      var message = 'Warning: ' + format.replace(/%s/g, function () {
-        return args[argIndex++];
-      });
-      if (typeof console !== 'undefined') {
-        console.error(message);
-      }
-      try {
-        // --- Welcome to debugging React ---
-        // This error was thrown as a convenience so that you can use this stack
-        // to find the callsite that caused this warning to fire.
-        throw new Error(message);
-      } catch (x) {}
-    };
-
-    warning = function warning(condition, format) {
-      if (format === undefined) {
-        throw new Error('`warning(condition, format, ...args)` requires a warning ' + 'message argument');
-      }
-
-      if (format.indexOf('Failed Composite propType: ') === 0) {
-        return; // Ignore CompositeComponent proptype check.
-      }
-
-      if (!condition) {
-        for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
-          args[_key2 - 2] = arguments[_key2];
-        }
-
-        printWarning.apply(undefined, [format].concat(args));
-      }
-    };
-  })();
+      printWarning.apply(undefined, [format].concat(args));
+    }
+  };
 }
 
 module.exports = warning;
@@ -3492,6 +3494,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');

--- a/src/EventsWrapper.js
+++ b/src/EventsWrapper.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { element, func } from 'prop-types'
 import defaults from './defaults'
-import { isEscapeKey, isEnterOrSpaceBarKey } from './keyboardEvents'
+import { isEnterOrSpaceBarKey, isEscapeKey, isTabKey } from './keyboardEvents'
 
 export default class EventsWrapper extends Component {
   constructor() {
@@ -57,6 +57,11 @@ export default class EventsWrapper extends Component {
   }
 
   _handleKeyDown(e) {
+    if (isTabKey(e)) {
+      e.preventDefault() // prevent in-behind controls from grabbing focus
+      return
+    }
+
     const { allowAccessibilityClose } = this.props
     const unzoomForEnterOrSpace =
       allowAccessibilityClose && isEnterOrSpaceBarKey(e)

--- a/src/keyboardEvents.js
+++ b/src/keyboardEvents.js
@@ -3,6 +3,11 @@ const enterKey = {
   keyCode: 13
 }
 
+const tabKey = {
+  keys: [ 'Tab' ],
+  keyCode: 9
+}
+
 const spaceBarKey = {
   keys: [ ' ' ],
   keyCode: 32
@@ -36,5 +41,6 @@ const isKey = ({ keyCode, keys }) => e =>
 
 // is<X>Key : KeyboardEvent -> Boolean
 export const isEnterOrSpaceBarKey = e => isKey(enterKey)(e) || isSpaceBarKey(e)
+export const isTabKey = isKey(tabKey)
 export const isSpaceBarKey = isKey(spaceBarKey)
 export const isEscapeKey = isKey(escapeKey)


### PR DESCRIPTION
This pull request fixes an issue where hitting the tab key on a zoomed imaged would allow an element in behind the image to receive focus. Further actions could then be taken on the focused element, causing the DOM to end up in undesired states.

## Pre-Flight Checklist
I have made sure to
- [X] make sure this PR is set to merge to the correct `X-0-stable` branch
- [X] add a Storybook example (if necessary)
- [X] manually test all the Storybook examples
  * run `$ yarn run storybook`
  * navigate to http://localhost:6006
- [X] run `$ yarn run build` to build the project code & static example
- [X] check that the example in `example/build/index.html` works: `$ open example/build/index.html`
