### PR TITLE
Fix zoomMargin not accepting number as string

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -496,9 +496,16 @@ var ImageZoom = function (_Component) {
     value: function render() {
       var _this2 = this;
 
-      var image = this.props.image,
+      var _props = this.props,
+          defaultStyles = _props.defaultStyles,
+          image = _props.image,
+          propsIsZoomed = _props.isZoomed,
+          shouldRespectMaxDimension = _props.shouldRespectMaxDimension,
+          zoomImage = _props.zoomImage,
+          zoomMargin = _props.zoomMargin,
           _state = this.state,
           isDisabled = _state.isDisabled,
+          stateIsZoomed = _state.isZoomed,
           src = _state.src;
 
       /**
@@ -515,7 +522,7 @@ var ImageZoom = function (_Component) {
         onClick: this._handleZoom,
         onKeyDown: this._handleKeyDown
       });
-      var isZoomed = isControlled(this.props.isZoomed) ? this.props.isZoomed : this.state.isZoomed;
+      var isZoomed = isControlled(propsIsZoomed) ? propsIsZoomed : stateIsZoomed;
 
       return [_react2.default.createElement('img', _extends({}, attrs, {
         key: 'image',
@@ -532,11 +539,11 @@ var ImageZoom = function (_Component) {
         controlledEventFn: this._getControlledEventFn(),
         allowAccessibilityClose: this._allowTabNavigation()
       }, _react2.default.createElement(_Zoom2.default, {
-        defaultStyles: this.props.defaultStyles,
+        defaultStyles: defaultStyles,
         image: this.image,
-        shouldRespectMaxDimension: this.props.shouldRespectMaxDimension,
-        zoomImage: this.props.zoomImage,
-        zoomMargin: this.props.zoomMargin,
+        shouldRespectMaxDimension: shouldRespectMaxDimension,
+        zoomImage: zoomImage,
+        zoomMargin: Number(zoomMargin),
         onUnzoom: this._handleUnzoom
       })) : null];
     }
@@ -553,9 +560,9 @@ var ImageZoom = function (_Component) {
   }, {
     key: '_checkShouldDisableComponent',
     value: function _checkShouldDisableComponent() {
-      var _props = this.props,
-          shouldRespectMaxDimension = _props.shouldRespectMaxDimension,
-          zoomImage = _props.zoomImage;
+      var _props2 = this.props,
+          shouldRespectMaxDimension = _props2.shouldRespectMaxDimension,
+          zoomImage = _props2.zoomImage;
 
       var isDisabled = shouldRespectMaxDimension && !zoomImage && (0, _helpers.isMaxDimension)(this.image);
 
@@ -565,10 +572,10 @@ var ImageZoom = function (_Component) {
     key: '_getImageStyle',
     value: function _getImageStyle() {
       var isClosing = this.isClosing,
-          _props2 = this.props,
-          defaultStyles = _props2.defaultStyles,
-          image = _props2.image,
-          isZoomedP = _props2.isZoomed,
+          _props3 = this.props,
+          defaultStyles = _props3.defaultStyles,
+          image = _props3.image,
+          isZoomedP = _props3.isZoomed,
           _state2 = this.state,
           isDisabled = _state2.isDisabled,
           isZoomedSt = _state2.isZoomed;

--- a/src/ImageZoom.js
+++ b/src/ImageZoom.js
@@ -98,8 +98,15 @@ export default class ImageZoom extends Component {
 
   render() {
     const {
-      props: { image },
-      state: { isDisabled, src }
+      props: {
+        defaultStyles,
+        image,
+        isZoomed: propsIsZoomed,
+        shouldRespectMaxDimension,
+        zoomImage,
+        zoomMargin
+      },
+      state: { isDisabled, isZoomed: stateIsZoomed, src }
     } = this
 
     /**
@@ -121,9 +128,7 @@ export default class ImageZoom extends Component {
         onKeyDown: this._handleKeyDown
       }
     )
-    const isZoomed = isControlled(this.props.isZoomed)
-      ? this.props.isZoomed
-      : this.state.isZoomed
+    const isZoomed = isControlled(propsIsZoomed) ? propsIsZoomed : stateIsZoomed
 
     return [
       <img
@@ -145,11 +150,11 @@ export default class ImageZoom extends Component {
           allowAccessibilityClose={this._allowTabNavigation()}
         >
           <Zoom
-            defaultStyles={this.props.defaultStyles}
+            defaultStyles={defaultStyles}
             image={this.image}
-            shouldRespectMaxDimension={this.props.shouldRespectMaxDimension}
-            zoomImage={this.props.zoomImage}
-            zoomMargin={this.props.zoomMargin}
+            shouldRespectMaxDimension={shouldRespectMaxDimension}
+            zoomImage={zoomImage}
+            zoomMargin={Number(zoomMargin)}
             onUnzoom={this._handleUnzoom}
           />
         </EventsWrapper>


### PR DESCRIPTION
This pull request closes https://github.com/rpearce/react-medium-image-zoom/issues/139.

cc @babyPrince

## Pre-Flight Checklist
I have made sure to
- [x] make sure this PR is set to merge to the correct `X-0-stable` branch
- [x] add a Storybook example (if necessary)
- [x] manually test all the Storybook examples
  * run `$ yarn run storybook`
  * navigate to http://localhost:6006
- [x] run `$ yarn run build` to build the project code & static example
- [x] check that the example in `example/build/index.html` works: `$ open example/build/index.html`
