### PR TITLE
Fixes JS error when _allowTabNavigation is called before image ref

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -671,7 +671,7 @@ var ImageZoom = function (_Component) {
   }, {
     key: '_allowTabNavigation',
     value: function _allowTabNavigation() {
-      return this.image.tabIndex !== unfocusableTabIndex;
+      return this.image && this.image.tabIndex !== unfocusableTabIndex;
     }
   }], [{
     key: 'defaultProps',

--- a/src/ImageZoom.js
+++ b/src/ImageZoom.js
@@ -272,7 +272,7 @@ export default class ImageZoom extends Component {
   }
 
   _allowTabNavigation() {
-    return this.image.tabIndex !== unfocusableTabIndex
+    return this.image && this.image.tabIndex !== unfocusableTabIndex
   }
 }
 


### PR DESCRIPTION
This pull request closes JS error seen in production:

![image](https://user-images.githubusercontent.com/380914/56461950-a9097600-636f-11e9-8b6a-91dd2d782f0a.png)

Whenever we're using a ref that's set post-mount it should be treated as though it won't always exist. I'm not sure what the correct "stable" branch is, let me know if the base needs changing.

## Pre-Flight Checklist
I have made sure to
- [ ] make sure this PR is set to merge to the correct `X-0-stable` branch
- [ ] add a Storybook example (if necessary)
- [x] manually test all the Storybook examples
  * run `$ yarn run storybook`
  * navigate to http://localhost:6006
- [x] run `$ yarn run build` to build the project code & static example
- [x] check that the example in `example/build/index.html` works: `$ open example/build/index.html`
