### PR TITLE
Update methods to be compatible with React.StrictMode

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "homepage": "https://github.com/rpearce/react-medium-image-zoom#readme",
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.4.8",
@@ -76,7 +76,7 @@
     "lint-staged": "^7.2.0",
     "nodemon": "^1.11.0",
     "prettier": "^1.14.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0"
   }
 }

--- a/src/ImageZoom.js
+++ b/src/ImageZoom.js
@@ -45,15 +45,22 @@ export default class ImageZoom extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  /**
+   * When the component's state updates, check for changes
+   * and either zoom or start the unzoom procedure.
+   * NOTE: We need to differentiate whether this is a
+   * controlled or uncontrolled component and do the check
+   * based off of that.
+   */
+  componentDidUpdate(prevProps, prevState) {
     if (
-      !isControlled(this.props.isZoomed) &&
-      isControlled(nextProps.isZoomed)
+      !isControlled(prevProps.isZoomed) &&
+      isControlled(this.props.isZoomed)
     ) {
       throw new Error(defaults.errors.uncontrolled)
     } else if (
-      isControlled(this.props.isZoomed) &&
-      !isControlled(nextProps.isZoomed)
+      isControlled(prevProps.isZoomed) &&
+      !isControlled(this.props.isZoomed)
     ) {
       throw new Error(defaults.errors.controlled)
     }
@@ -64,27 +71,18 @@ export default class ImageZoom extends Component {
      * hiding the original image on the page until the
      * unzooming is complete
      */
-    if (this.props.isZoomed && !nextProps.isZoomed) {
+    if (prevProps.isZoomed && !this.props.isZoomed) {
       this.isClosing = true
     }
 
-    const { src } = this.props.image
-    const { src: nextSrc } = nextProps.image
+    const { src } = prevProps.image
+    const { src: nextSrc } = this.props.image
 
     // If the consumer wants to change the image's src, then so be it.
     if (src !== nextSrc) {
       this.setState({ src: nextSrc })
     }
-  }
 
-  /**
-   * When the component's state updates, check for changes
-   * and either zoom or start the unzoom procedure.
-   * NOTE: We need to differentiate whether this is a
-   * controlled or uncontrolled component and do the check
-   * based off of that.
-   */
-  componentDidUpdate(prevProps, prevState) {
     const prevIsZoomed = isControlled(prevProps.isZoomed)
       ? prevProps.isZoomed
       : prevState.isZoomed

--- a/src/ImageZoom.js
+++ b/src/ImageZoom.js
@@ -18,7 +18,10 @@ export default class ImageZoom extends Component {
     this.state = {
       isDisabled: false,
       isZoomed: false,
-      src: props.image.src
+      wasZoomed: false,
+      src: props.image.src,
+      prevSrc: props.image.src,
+      isClosing: false
     }
 
     this._handleKeyDown = this._handleKeyDown.bind(this)
@@ -45,6 +48,26 @@ export default class ImageZoom extends Component {
     }
   }
 
+  static getDerivedStateFromProps(props, state) {
+    /**
+     * When component is controlled, we need a flag
+     * set when it's about to close in order to keep
+     * hiding the original image on the page until the
+     * unzooming is complete
+     */
+    const isClosing = state.wasZoomed && !props.isZoomed || state.isClosing
+    // If the consumer wants to change the image's src, then so be it.
+    const src = props.image.src !== state.prevSrc ? props.image.src : state.src
+
+    return {
+      src,
+      isClosing,
+      // Keep track of previous props
+      wasZoomed: props.isZoomed,
+      prevSrc: props.image.src
+    }
+  }
+
   /**
    * When the component's state updates, check for changes
    * and either zoom or start the unzoom procedure.
@@ -63,24 +86,6 @@ export default class ImageZoom extends Component {
       !isControlled(this.props.isZoomed)
     ) {
       throw new Error(defaults.errors.controlled)
-    }
-
-    /**
-     * When component is controlled, we need a flag
-     * set when it's about to close in order to keep
-     * hiding the original image on the page until the
-     * unzooming is complete
-     */
-    if (prevProps.isZoomed && !this.props.isZoomed) {
-      this.isClosing = true
-    }
-
-    const { src } = prevProps.image
-    const { src: nextSrc } = this.props.image
-
-    // If the consumer wants to change the image's src, then so be it.
-    if (src !== nextSrc) {
-      this.setState({ src: nextSrc })
     }
 
     const prevIsZoomed = isControlled(prevProps.isZoomed)
@@ -104,7 +109,7 @@ export default class ImageZoom extends Component {
         zoomImage,
         zoomMargin
       },
-      state: { isDisabled, isZoomed: stateIsZoomed, src }
+      state: { isDisabled, isZoomed: stateIsZoomed, src, isClosing }
     } = this
 
     /**
@@ -138,7 +143,7 @@ export default class ImageZoom extends Component {
         onLoad={this._handleLoad}
         onError={this._handleLoadError}
       />,
-      this.image && (isZoomed || this.isClosing) ?
+      this.image && (isZoomed || isClosing) ?
         <EventsWrapper
           key="portal"
           ref={node => {
@@ -178,9 +183,8 @@ export default class ImageZoom extends Component {
 
   _getImageStyle() {
     const {
-      isClosing,
       props: { defaultStyles, image, isZoomed: isZoomedP },
-      state: { isDisabled, isZoomed: isZoomedSt }
+      state: { isDisabled, isZoomed: isZoomedSt, isClosing }
     } = this
 
     const isHidden = isZoomedSt || isZoomedP || isClosing
@@ -244,18 +248,9 @@ export default class ImageZoom extends Component {
   _handleUnzoom(src, allowRefocus) {
     return () => {
       const changes = Object.assign(
-        { isZoomed: false },
+        { isZoomed: false, isClosing: false },
         this.props.shouldReplaceImage && { src }
       )
-
-      /**
-       * Lamentable but necessary right now in order to
-       * remove the portal instance before the next
-       * `componentDidUpdate` check for the portalInstance.
-       * The reasoning is so we can differentiate between an
-       * external `isZoomed` command and an internal one.
-       */
-      delete this.isClosing
 
       this.setState(changes, this.props.onUnzoom)
 

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,29 +1,18 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import { bool, object } from 'prop-types'
 import defaults from './defaults'
 
-export default class Overlay extends Component {
+export default class Overlay extends PureComponent {
   constructor(props) {
     super(props)
 
     this.state = {
-      isVisible: false
+      isMounted: false
     }
   }
 
   componentDidMount() {
-    this.setState({ isVisible: true })
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (!nextProps.isVisible) this.setState({ isVisible: false })
-  }
-
-  shouldComponentUpdate(nextProps) {
-    return (
-      this.props.isVisible !== nextProps.isVisible ||
-      this.state.isVisible !== nextProps.isVisible
-    )
+    this.setState({ isMounted: true })
   }
 
   render() {
@@ -31,7 +20,8 @@ export default class Overlay extends Component {
   }
 
   _getStyle() {
-    const opacity = this.state.isVisible & 1 // bitwise and; converts bool to 0 or 1
+    const isVisible = this.state.isMounted && this.props.isVisible
+    const opacity = isVisible & 1 // bitwise and; converts bool to 0 or 1
     return Object.assign(
       {},
       defaults.styles.overlay,


### PR DESCRIPTION
This pull request doesn't fix (the following issue) #143 but addresses the removal of now deprecated methods in React 16 to be compatible with `<React.StrictMode>`.
Since it now uses the `getDerivedStateFromProps` lifecycle method in its actual state, I set the minimum required version of `react` and `react-dom` to `^16.4.0` which [includes the bugfix](https://reactjs.org/blog/2018/05/23/react-v-16-4.html#bugfix-for-getderivedstatefromprops) for this method.

I don't have time to improve it better (switching to hooks, etc...) right now, but would be happy to do so when I can find some spare time later.

## Pre-Flight Checklist
I have made sure to
- [ ] ? make sure this PR is set to merge to the correct `X-0-stable` branch
- [ ] ~~add a Storybook example (if necessary)~~
- [x] manually test all the Storybook examples
  * run `$ yarn run storybook`
  * navigate to http://localhost:6006
- [x] run `$ yarn run build` to build the project code & static example
- [x] check that the example in `docs/index.html` works: `$ yarn run start`
