### PR TITLE
Used Fragment instead of Array in render method to support Preact

### DIFF
--- a/src/ImageZoom.js
+++ b/src/ImageZoom.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { bool, func, object, shape, string } from 'prop-types'
 import defaults from './defaults'
 import { isMaxDimension } from './helpers'
@@ -133,36 +133,38 @@ export default class ImageZoom extends Component {
     )
     const isZoomed = isControlled(propsIsZoomed) ? propsIsZoomed : stateIsZoomed
 
-    return [
-      <img
-        {...attrs}
-        key="image"
-        ref={x => {
-          this.image = x
-        }}
-        onLoad={this._handleLoad}
-        onError={this._handleLoadError}
-      />,
-      this.image && (isZoomed || isClosing) ?
-        <EventsWrapper
-          key="portal"
-          ref={node => {
-            this.portalInstance = node
+    return (
+      <Fragment>
+        <img
+          {...attrs}
+          key="image"
+          ref={x => {
+            this.image = x
           }}
-          controlledEventFn={this._getControlledEventFn()}
-          allowAccessibilityClose={this._allowTabNavigation()}
-        >
-          <Zoom
-            defaultStyles={defaultStyles}
-            image={this.image}
-            shouldRespectMaxDimension={shouldRespectMaxDimension}
-            zoomImage={zoomImage}
-            zoomMargin={Number(zoomMargin)}
-            onUnzoom={this._handleUnzoom}
-          />
-        </EventsWrapper>
-       : null
-    ]
+          onLoad={this._handleLoad}
+          onError={this._handleLoadError}
+        />
+        {this.image && (isZoomed || isClosing) ?
+          <EventsWrapper
+            key="portal"
+            ref={node => {
+              this.portalInstance = node
+            }}
+            controlledEventFn={this._getControlledEventFn()}
+            allowAccessibilityClose={this._allowTabNavigation()}
+          >
+            <Zoom
+              defaultStyles={defaultStyles}
+              image={this.image}
+              shouldRespectMaxDimension={shouldRespectMaxDimension}
+              zoomImage={zoomImage}
+              zoomMargin={Number(zoomMargin)}
+              onUnzoom={this._handleUnzoom}
+            />
+          </EventsWrapper>
+        : null}
+      </Fragment>
+    );
   }
 
   /**


### PR DESCRIPTION
Preact doesn't support Array, hence used Fragment.
Reference URL: https://github.com/preactjs/preact/issues/929

This pull request closes (past link to GitHub issue here).

## Pre-Flight Checklist
I have made sure to
- [ ✅] make sure this PR is set to merge to the correct `X-0-stable` branch
- [ ✅] add a Storybook example (if necessary)
- [ ✅] manually test all the Storybook examples
  * run `$ yarn run storybook`
  * navigate to http://localhost:6006
- [ ✅] run `$ yarn run build` to build the project code & static example
- [ ✅] check that the example in `example/build/index.html` works: `$ open example/build/index.html`
