### PR TITLE
Fix weird CSSProperties issue by setting moduleResolution to nodenext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "jsx": "react",
     "lib": ["esnext", "dom"],
     "module": "esnext",
+    "moduleResolution": "nodenext",
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
TS was complaining about this:

```
Property 'height' does not exist on type 'CSSProperties'
```

Which was weird. Setting `moduleResolution` to `nodenext` seems to resolve it.