### PR TITLE
Portalize <dialog> to avoid invalid HTML issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Ability to customize the zoom modal content via `<ZoomContent>` (issue #332)
 
+### Changed
+
+* Now rendering `<dialog>` in a portal because of #356
+
 ## [5.0.3] - 2022-09-19
 
 ### Fixed
 
 * Missing class properties transform (#337) (potential issue versions of node
   older than LTS)
->>>>>>> main
 
 ## [5.0.2] - 2022-08-22
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Here are the prop changes from `v4` to be aware of:
 * `overlayBgColorEnd` was removed and is now controlled via the CSS selector `[data-rmiz-modal-overlay="visible"]`
 * `portalEl` was removed, for we are using the `<dialog>` element now
 * `transitionDuration` was removed and is now controlled via the CSS selectors `[data-rmiz-modal-overlay]` and `[data-rmiz-modal-img]`
-* `wrapElement` was removed then added back in `v5.1.0`
+* `wrapElement` was removed
 * `wrapStyle` was removed
 * `zoomZindex` was removed, for we are using the `<dialog>` element now
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Here are the prop changes from `v4` to be aware of:
 * `overlayBgColorEnd` was removed and is now controlled via the CSS selector `[data-rmiz-modal-overlay="visible"]`
 * `portalEl` was removed, for we are using the `<dialog>` element now
 * `transitionDuration` was removed and is now controlled via the CSS selectors `[data-rmiz-modal-overlay]` and `[data-rmiz-modal-img]`
-* `wrapElement` was removed
+* `wrapElement` was removed then added back in `v5.1.0`
 * `wrapStyle` was removed
 * `zoomZindex` was removed, for we are using the `<dialog>` element now
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Here are the prop changes from `v4` to be aware of:
 * `overlayBgColorEnd` was removed and is now controlled via the CSS selector `[data-rmiz-modal-overlay="visible"]`
 * `portalEl` was removed, for we are using the `<dialog>` element now
 * `transitionDuration` was removed and is now controlled via the CSS selectors `[data-rmiz-modal-overlay]` and `[data-rmiz-modal-img]`
-* `wrapElement` was removed
+* `wrapElement` was removed then added back in `v5.1.0`
 * `wrapStyle` was removed
 * `zoomZindex` was removed, for we are using the `<dialog>` element now
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "5.1.0-beta.3",
+  "version": "5.1.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-medium-image-zoom",
-      "version": "5.1.0-beta.3",
+      "version": "5.1.0-beta.4",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "5.1.0-beta.2",
+  "version": "5.1.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-medium-image-zoom",
-      "version": "5.1.0-beta.2",
+      "version": "5.1.0-beta.3",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "contributors:generate": "all-contributors generate",
     "lint": "eslint .",
     "prepublishOnly": "concurrently npm:lint npm:build",
-    "start": "start-storybook -p 6006",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "test-storybook": "test-storybook"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "5.1.0-beta.2",
+  "version": "5.1.0-beta.3",
   "license": "BSD-3-Clause",
   "description": "Accessible medium.com-style image zoom for React",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "5.1.0-beta.3",
+  "version": "5.1.0-beta.4",
   "license": "BSD-3-Clause",
   "description": "Accessible medium.com-style image zoom for React",
   "type": "module",

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -27,6 +27,16 @@ import {
 
 // =============================================================================
 
+let elDialogContainer: HTMLDivElement
+
+if (typeof document !== 'undefined') {
+  elDialogContainer = document.createElement('div')
+  elDialogContainer.setAttribute('data-rmiz-portal', '')
+  document.body.appendChild(elDialogContainer)
+}
+
+// =============================================================================
+
 const enum ModalState {
   LOADED = 'LOADED',
   LOADING = 'LOADING',
@@ -45,7 +55,6 @@ export interface ControlledProps {
   isZoomed: boolean
   onZoomChange?: (value: boolean) => void
   scrollableEl?: Window | HTMLElement
-  wrapElement?: ElementType
   ZoomContent?: (data: {
     img: ReactElement | null
     buttonUnzoom: ReactElement<HTMLButtonElement>
@@ -65,7 +74,6 @@ interface ControlledDefaultProps {
   a11yNameButtonZoom: string
   IconUnzoom: ElementType
   IconZoom: ElementType
-  wrapElement: ElementType,
   zoomMargin: number
 }
 
@@ -85,7 +93,6 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     a11yNameButtonZoom: 'Expand image',
     IconUnzoom: ICompress,
     IconZoom: IEnlarge,
-    wrapElement: 'div',
     zoomMargin: 0,
   }
 
@@ -122,7 +129,6 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
         IconUnzoom,
         IconZoom,
         isZoomed,
-        wrapElement: WrapElement,
         ZoomContent,
         zoomImg,
         zoomMargin,
@@ -242,11 +248,11 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     // =========================================================================
 
     return (
-      <WrapElement data-rmiz="" ref={refWrap}>
-        <WrapElement data-rmiz-content={dataContentState} ref={refContent} style={styleContent}>
+      <div data-rmiz="" ref={refWrap}>
+        <div data-rmiz-content={dataContentState} ref={refContent} style={styleContent}>
           {children}
-        </WrapElement>
-        {hasImage && <WrapElement data-rmiz-ghost="" style={styleGhost}>
+        </div>
+        {hasImage && <div data-rmiz-ghost="" style={styleGhost}>
           <button
             aria-label={labelBtnZoom}
             data-rmiz-btn-zoom=""
@@ -255,7 +261,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
           >
             <IconZoom />
           </button>
-        </WrapElement>}
+        </div>}
         {hasImage && document?.body != null && createPortal(
           <dialog /* eslint-disable-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-redundant-roles */
             aria-labelledby={idModalImg}
@@ -272,9 +278,9 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
               {modalContent}
             </div>
           </dialog>
-          , document.body
+          , elDialogContainer
         )}
-      </WrapElement>
+      </div>
     )
   }
 

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -8,6 +8,8 @@ import React, {
   createRef,
 } from 'react'
 
+import { createPortal } from 'react-dom'
+
 import type { SupportedImage } from './types'
 import { IEnlarge, ICompress } from './icons'
 
@@ -196,46 +198,49 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
             <IconZoom />
           </button>
         </div>}
-        {hasImage && <dialog /* eslint-disable-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-redundant-roles */
-          aria-labelledby={idModalImg}
-          aria-modal="true"
-          data-rmiz-modal=""
-          ref={refDialog}
-          onClick={handleUnzoom}
-          onClose={handleUnzoom /* eslint-disable-line react/no-unknown-property */}
-          onKeyDown={handleDialogKeyDown}
-          role="dialog"
-        >
-          <div data-rmiz-modal-overlay={dataOverlayState} />
-          <div data-rmiz-modal-content="">
-            {(isImg || isDiv) && <img
-              alt={imgAlt}
-              sizes={imgSizes}
-              src={imgSrc}
-              srcSet={imgSrcSet}
-              {...isZoomImgLoaded && modalState === ModalState.LOADED ? zoomImg : {}}
-              data-rmiz-modal-img=""
-              height={this.styleModalImg.height}
-              id={idModalImg}
-              ref={refModalImg}
-              style={this.styleModalImg}
-              width={this.styleModalImg.width}
-            />}
-            {isSvg && <div
-              data-rmiz-modal-img=""
-              ref={refModalImg}
-              style={this.styleModalImg}
-            />}
-            <button
-              aria-label={a11yNameButtonUnzoom}
-              data-rmiz-btn-unzoom=""
-              onClick={handleUnzoom}
-              type="button"
-            >
-              <IconUnzoom />
-            </button>
-          </div>
-        </dialog>}
+        {hasImage && document?.body != null && createPortal(
+          <dialog /* eslint-disable-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-redundant-roles */
+            aria-labelledby={idModalImg}
+            aria-modal="true"
+            data-rmiz-modal=""
+            ref={refDialog}
+            onClick={handleUnzoom}
+            onClose={handleUnzoom /* eslint-disable-line react/no-unknown-property */}
+            onKeyDown={handleDialogKeyDown}
+            role="dialog"
+          >
+            <div data-rmiz-modal-overlay={dataOverlayState} />
+            <div data-rmiz-modal-content="">
+              {(isImg || isDiv) && <img
+                alt={imgAlt}
+                sizes={imgSizes}
+                src={imgSrc}
+                srcSet={imgSrcSet}
+                {...isZoomImgLoaded && modalState === ModalState.LOADED ? zoomImg : {}}
+                data-rmiz-modal-img=""
+                height={this.styleModalImg.height}
+                id={idModalImg}
+                ref={refModalImg}
+                style={this.styleModalImg}
+                width={this.styleModalImg.width}
+              />}
+              {isSvg && <div
+                data-rmiz-modal-img=""
+                ref={refModalImg}
+                style={this.styleModalImg}
+              />}
+              <button
+                aria-label={a11yNameButtonUnzoom}
+                data-rmiz-btn-unzoom=""
+                onClick={handleUnzoom}
+                type="button"
+              >
+                <IconUnzoom />
+              </button>
+            </div>
+          </dialog>
+          , document.body
+        )}
       </WrapElement>
     )
   }

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -41,6 +41,7 @@ export interface ControlledProps {
   isZoomed: boolean
   onZoomChange?: (value: boolean) => void
   scrollableEl?: Window | HTMLElement
+  wrapElement?: ElementType
   zoomImg?: ImgHTMLAttributes<HTMLImageElement>
   zoomMargin?: number
 }
@@ -54,6 +55,7 @@ interface ControlledDefaultProps {
   a11yNameButtonZoom: string
   IconUnzoom: ElementType
   IconZoom: ElementType
+  wrapElement: ElementType,
   zoomMargin: number
 }
 
@@ -73,6 +75,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     a11yNameButtonZoom: 'Expand image',
     IconUnzoom: ICompress,
     IconZoom: IEnlarge,
+    wrapElement: 'div',
     zoomMargin: 0,
   }
 
@@ -107,6 +110,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
         IconUnzoom,
         IconZoom,
         isZoomed,
+        wrapElement: WrapElement,
         zoomImg,
         zoomMargin,
       },
@@ -178,10 +182,10 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     // =========================================================================
 
     return (
-      <div data-rmiz="" ref={refWrap}>
-        <div data-rmiz-content={dataContentState} ref={refContent} style={styleContent}>
+      <WrapElement data-rmiz="" ref={refWrap}>
+        <WrapElement data-rmiz-content={dataContentState} ref={refContent} style={styleContent}>
           {children}
-        </div>
+        </WrapElement>
         {hasImage && <div data-rmiz-ghost="" style={styleGhost}>
           <button
             aria-label={labelBtnZoom}
@@ -232,7 +236,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
             </button>
           </div>
         </dialog>}
-      </div>
+      </WrapElement>
     )
   }
 

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -55,6 +55,7 @@ export interface ControlledProps {
   isZoomed: boolean
   onZoomChange?: (value: boolean) => void
   scrollableEl?: Window | HTMLElement
+  wrapElement?: ElementType
   ZoomContent?: (data: {
     img: ReactElement | null
     buttonUnzoom: ReactElement<HTMLButtonElement>
@@ -74,6 +75,7 @@ interface ControlledDefaultProps {
   a11yNameButtonZoom: string
   IconUnzoom: ElementType
   IconZoom: ElementType
+  wrapElement: ElementType
   zoomMargin: number
 }
 
@@ -93,6 +95,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     a11yNameButtonZoom: 'Expand image',
     IconUnzoom: ICompress,
     IconZoom: IEnlarge,
+    wrapElement: 'div',
     zoomMargin: 0,
   }
 
@@ -129,6 +132,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
         IconUnzoom,
         IconZoom,
         isZoomed,
+        wrapElement: WrapElement,
         ZoomContent,
         zoomImg,
         zoomMargin,
@@ -248,11 +252,11 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     // =========================================================================
 
     return (
-      <div data-rmiz="" ref={refWrap}>
-        <div data-rmiz-content={dataContentState} ref={refContent} style={styleContent}>
+      <WrapElement data-rmiz="" ref={refWrap}>
+        <WrapElement data-rmiz-content={dataContentState} ref={refContent} style={styleContent}>
           {children}
-        </div>
-        {hasImage && <div data-rmiz-ghost="" style={styleGhost}>
+        </WrapElement>
+        {hasImage && <WrapElement data-rmiz-ghost="" style={styleGhost}>
           <button
             aria-label={labelBtnZoom}
             data-rmiz-btn-zoom=""
@@ -261,7 +265,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
           >
             <IconZoom />
           </button>
-        </div>}
+        </WrapElement>}
         {hasImage && document?.body != null && createPortal(
           <dialog /* eslint-disable-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-redundant-roles */
             aria-labelledby={idModalImg}
@@ -280,7 +284,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
           </dialog>
           , elDialogContainer
         )}
-      </div>
+      </WrapElement>
     )
   }
 

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -154,24 +154,36 @@ export const SmallSrcSize: ComponentStory<typeof Zoom> = (props) => (
 
 // =============================================================================
 
-export const CustomModalStyles: ComponentStory<typeof Zoom> = (props) => (
-  <main aria-label="Story">
-    <h1>Custom Modal Styles</h1>
-    <div className="mw-600">
-      <p>Use CSS to customize the zoom modal styles.</p>
-      <p>Here, we slow down the transition time and use a different overlay color.</p>
-      <div className="custom-zoom">
-        <Zoom {...props}>
-          <img
-            alt={imgGlenorchyLagoon.alt}
-            src={imgGlenorchyLagoon.src}
-            width="400"
-          />
-        </Zoom>
-      </div>
-      <p>The CSS to do this:</p>
-      <pre>
-        <code>{`
+export const CustomModalStyles: ComponentStory<typeof Zoom> = (props) => {
+  useEffect(() => {
+    document.body.classList.add('custom-zoom')
+
+    return () => {
+      document.body.classList.remove('custom-zoom')
+    }
+  }, [])
+
+  return (
+    <main aria-label="Story">
+      <h1>Custom Modal Styles</h1>
+      <div className="mw-600">
+        <p>Use CSS to customize the zoom modal styles.</p>
+        <p>Here, we slow down the transition time and use a different overlay color.</p>
+        <div>
+          <Zoom {...props}>
+            <img
+              alt={imgGlenorchyLagoon.alt}
+              src={imgGlenorchyLagoon.src}
+              width="400"
+            />
+          </Zoom>
+        </div>
+        <p>
+          The CSS class, <code>custom-zoom</code>, is on
+          the <code>body</code> element:
+        </p>
+        <pre>
+          <code>{`
 .custom-zoom [data-rmiz-modal-overlay],
 .custom-zoom [data-rmiz-modal-img] {
   transition-duration: 0.8s;
@@ -192,11 +204,12 @@ export const CustomModalStyles: ComponentStory<typeof Zoom> = (props) => (
   outline: 0.2rem solid #bd93f9;
 }
 `}
-        </code>
-      </pre>
-    </div>
-  </main>
-)
+          </code>
+        </pre>
+      </div>
+    </main>
+  )
+}
 
 // =============================================================================
 
@@ -379,12 +392,12 @@ export const CustomButtonIcons: ComponentStory<typeof Zoom> = (props) => (
 
 // =============================================================================
 
-export const WrapElementSpan: ComponentStory<typeof Zoom> = (props) => (
+export const InlineImage: ComponentStory<typeof Zoom> = (props) => (
   <main aria-label="Story">
-    <h1>Using spans as wrapElements</h1>
-    <p className="wrap-element-example">
-      This example uses spans instead of divs for the Zoom component.
-      <Zoom {...props} wrapElement="span">
+    <h1>Inline Image</h1>
+    <p className="inline">
+      This example is of an image that is inline with text.
+      <Zoom {...props}>
         <img
           alt={imgThatWanakaTree.alt}
           decoding="async"
@@ -401,8 +414,7 @@ export const WrapElementSpan: ComponentStory<typeof Zoom> = (props) => (
 // INTERACTIONS
 
 export const WithRegularZoomed = Regular.bind({})
-WithRegularZoomed.play = async ({ canvasElement, ...rest }) => {
-  console.log(rest)
+WithRegularZoomed.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
 
   await waitFor(async () => {

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -312,7 +312,8 @@ export const WrapElementSpan: ComponentStory<typeof Zoom> = (props) => (
 // INTERACTIONS
 
 export const WithRegularZoomed = Regular.bind({})
-WithRegularZoomed.play = async ({ canvasElement }) => {
+WithRegularZoomed.play = async ({ canvasElement, ...rest }) => {
+  console.log(rest)
   const canvas = within(canvasElement)
 
   await waitFor(async () => {
@@ -324,8 +325,8 @@ WithRegularZoomed.play = async ({ canvasElement }) => {
   await userEvent.keyboard('{Enter}', { delay: 1000 })
 
   await waitFor(async () => {
-    await expect(canvas.getByRole('dialog')).toHaveAttribute('open')
-    await expect(canvas.getByRole('dialog').querySelector(`img[alt="${imgThatWanakaTree.alt}"]`)).toBeVisible()
-    await expect(canvas.getByLabelText('Minimize image')).toHaveFocus()
+    await expect(document.querySelector('dialog')).toHaveAttribute('open')
+    await expect(document.querySelector('dialog').querySelector(`img[alt="${imgThatWanakaTree.alt}"]`)).toBeVisible()
+    await expect(document.querySelector('dialog').querySelector('[aria-label="Minimize image"')).toHaveFocus()
   })
 }

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -293,16 +293,18 @@ export const CustomButtonIcons: ComponentStory<typeof Zoom> = (props) => (
 export const WrapElementSpan: ComponentStory<typeof Zoom> = (props) => (
   <main aria-label="Story">
     <h1>Using spans as wrapElements</h1>
-    <div className="mw-600">
+    <p className="wrap-element-example">
+      This example uses spans instead of divs for the Zoom component.
       <Zoom {...props} wrapElement="span">
         <img
           alt={imgThatWanakaTree.alt}
+          decoding="async"
           src={imgThatWanakaTree.src}
           height="320"
           loading="lazy"
         />
       </Zoom>
-    </div>
+    </p>
   </main>
 )
 

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -397,7 +397,7 @@ export const InlineImage: ComponentStory<typeof Zoom> = (props) => (
     <h1>Inline Image</h1>
     <p className="inline">
       This example is of an image that is inline with text.
-      <Zoom {...props}>
+      <Zoom {...props} wrapElement="span">
         <img
           alt={imgThatWanakaTree.alt}
           decoding="async"

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -289,6 +289,24 @@ export const CustomButtonIcons: ComponentStory<typeof Zoom> = (props) => (
 )
 
 // =============================================================================
+
+export const WrapElementSpan: ComponentStory<typeof Zoom> = (props) => (
+  <main aria-label="Story">
+    <h1>Using spans as wrapElements</h1>
+    <div className="mw-600">
+      <Zoom {...props} wrapElement="span">
+        <img
+          alt={imgThatWanakaTree.alt}
+          src={imgThatWanakaTree.src}
+          height="320"
+          loading="lazy"
+        />
+      </Zoom>
+    </div>
+  </main>
+)
+
+// =============================================================================
 // INTERACTIONS
 
 export const WithRegularZoomed = Regular.bind({})

--- a/stories/base.css
+++ b/stories/base.css
@@ -87,7 +87,7 @@ img {
   width: 15px;
   line-height: 0;
 }
-.wrap-element-example [data-rmiz] img {
+.inline [data-rmiz] img {
   display: inline-block;
   vertical-align: middle;
 }

--- a/stories/base.css
+++ b/stories/base.css
@@ -87,3 +87,7 @@ img {
   width: 15px;
   line-height: 0;
 }
+.wrap-element-example [data-rmiz] img {
+  display: inline-block;
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Description

This pull request closes https://github.com/rpearce/react-medium-image-zoom/issues/356 ~by adding `wrapElement` back to the API. Honestly, I forgot about https://github.com/rpearce/react-medium-image-zoom/pull/238~.

~However, allowing `<span>` or `<p>` or any element that can only have "Phrasing content" (inline elements, really) as a parent creates an issue, for the `<dialog>` element is block-level. To remediate this, I'm seeing if leveraging a portal for the `<dialog>` is a wise decision.~ It seems that the portal might be the way to go. Continued testing will have the final say.


