### PR TITLE
Replace scrollableEl with wheel event; fix mobile swiping/scrolling experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [5.1.0] - 2022-09-30
+## [5.1.0] - 2022-10-06
 
 ### Added
 
@@ -17,7 +17,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Now rendering `<dialog>` in a portal because of #356. This will affect the
   probably non-existent portion of people using CSS like `.my-class
-  [data-rmiz] {}`.
+  [data-rmiz] {}`
+
+### Fixed
+
+* Now using the `wheel` event instead of `scroll` to detect trying to leave the
+  modal (issue #350)
+* Fixed mobile scrolling experience (related to issue #350)
+
+### Removed
+
+* Removed the broken `scrollableEl` that has arguably not ever worked (issue #350)
 
 ## [5.0.3] - 2022-09-19
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ export interface UncontrolledProps {
   // Default: IEnlarge
   IconZoom?: ElementType
 
-  // Scrollable parent element
-  // Default: window
-  scrollableEl?: Window | HTMLElement
-
   // Provide your own custom modal content component
   ZoomContent?: (props: {
     img: ReactElement | null;

--- a/source/styles.css
+++ b/source/styles.css
@@ -49,9 +49,6 @@
 [data-rmiz-content="found"] [data-zoom] {
   cursor: zoom-in;
 }
-[data-rmiz-modal] {
-  pointer-events: none;
-}
 [data-rmiz-modal]::backdrop {
   display: none;
 }
@@ -91,7 +88,6 @@
   image-rendering: high-quality;
   transform-origin: top left;
   transition: transform 0.3s;
-  will-change: transform;
 }
 @media (prefers-reduced-motion: reduce) {
   [data-rmiz-modal-overlay],


### PR DESCRIPTION
## Description

This pull request addresses the `scrollableEl` portion of https://github.com/rpearce/react-medium-image-zoom/issues/350 and replaces a faulty dependence on listening for `scroll` events on the document to now listening for `wheel` events.

This PR also goes to great lengths to make the mobile experience incredibly smooth while also allowing for zooming and panning.

This also moves the listeners to being `{ passive: true }`, but TypeScript complains when I pass that arg to `removeEventListener` as the 3rd arg. According to the MDN docs, the only thing that matters is if `useCapture`/`capture` is used, but it does state that there are potential inconsistencies. Time will tell! 