### PR TITLE
Fix not supporting display: none; images

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -182,7 +182,10 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     const imgSrcSet = isImg ? imgEl.srcset : undefined
 
     const hasZoomImg = !!zoomImg?.src
-    const hasImage = imgEl && (loadedImgEl || isSvg)
+
+    const hasImage = imgEl &&
+      (loadedImgEl || isSvg) &&
+      window.getComputedStyle(imgEl).display !== 'none'
 
     const labelBtnZoom = imgAlt
       ? `${a11yNameButtonZoom}: ${imgAlt}`

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -23,6 +23,7 @@ import {
   imgKeaSmall,
   imgNzMap,
   imgTeAraiPoint,
+  imgTekapo,
   imgThatWanakaTree,
 } from './images'
 
@@ -322,19 +323,7 @@ const DelayedImg = (props: DelayedImgProps) => {
 }
 
 export const DelayedImageRender: ComponentStory<typeof Zoom> = (props) => {
-  const [timer, setTimer] = useState(5000)
-
-  useEffect(() => {
-    const interval = setInterval(function () {
-      if (timer === 0) {
-        clearInterval(this)
-      } else {
-        setTimer(timer - 1000)
-      }
-    }, 1000)
-
-    return () => clearInterval(interval)
-  }, [timer])
+  const { timer } = useTimer(5000)
 
   return (
     <main aria-label="Story">
@@ -355,6 +344,38 @@ export const DelayedImageRender: ComponentStory<typeof Zoom> = (props) => {
             src={imgEarth.src}
             height="200"
             width="400"
+          />
+        </Zoom>
+      </div>
+    </main>
+  )
+}
+
+// =============================================================================
+
+export const DelayedDisplayNone: ComponentStory<typeof Zoom> = (props) => {
+  const { timer } = useTimer(5000)
+  const classImg = timer === 0 ? undefined : 'display-none'
+
+  return (
+    <main aria-label="Story">
+      <h1>A delayed <code>display: none;</code> image</h1>
+      <div className="mw-600">
+        <p>
+          This examples simulates an image being hidden with CSS and then shown
+          after the countdown.
+        </p>
+        <div>
+          Image loads in: <span role="timer">{timer / 1000}</span>
+        </div>
+        <Zoom {...props}>
+          <img
+            alt={imgTekapo.alt}
+            src={imgTekapo.src}
+            className={classImg}
+            decoding="async"
+            height="320"
+            loading="lazy"
           />
         </Zoom>
       </div>
@@ -392,8 +413,8 @@ export const InlineImage: ComponentStory<typeof Zoom> = (props) => (
       <Zoom {...props} wrapElement="span">
         <img
           alt={imgThatWanakaTree.alt}
-          decoding="async"
           src={imgThatWanakaTree.src}
+          decoding="async"
           height="320"
           loading="lazy"
         />
@@ -437,4 +458,22 @@ const cx = (mods) => {
   }
 
   return cns.join(' ')
+}
+
+const useTimer = (duration: number) => {
+  const [timer, setTimer] = useState(duration)
+
+  useEffect(() => {
+    const interval = setInterval(function () {
+      if (timer === 0) {
+        clearInterval(this)
+      } else {
+        setTimer(timer - 1000)
+      }
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [timer])
+
+  return { timer }
 }

--- a/stories/base.css
+++ b/stories/base.css
@@ -41,6 +41,9 @@ img {
   display: block;
   max-width: 100%;
 }
+.display-none {
+  display: none;
+}
 .mw-600 {
   max-width: 60rem;
 }


### PR DESCRIPTION
## Description

This pull request addresses https://github.com/rpearce/react-medium-image-zoom/issues/357

## Testing

1. Run the storybook locally
2. Go to http://localhost:6006/?path=/story/img--delayed-display-none
3. Ensure you can use the zoom after the image is shown
