### PR TITLE
Fix zoomMargin measuring

### DIFF
--- a/source/utils.ts
+++ b/source/utils.ts
@@ -26,8 +26,8 @@ export interface GetScaleToWindow {
 
 export const getScaleToWindow: GetScaleToWindow = ({ height, offset, width }) => {
   return Math.min(
-    window.innerWidth / (width + offset), // scale X-axis
-    window.innerHeight / (height + offset) // scale Y-axis
+    (window.innerWidth - offset * 2) / width, // scale X-axis
+    (window.innerHeight - offset * 2) / height // scale Y-axis
   )
 }
 

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -53,6 +53,25 @@ export const Regular: ComponentStory<typeof Zoom> = (props) => (
 
 // =============================================================================
 
+export const ZoomMargin: ComponentStory<typeof Zoom> = (props) => (
+  <main aria-label="Story">
+    <h1>Setting a zoomMargin of 45(px)</h1>
+    <div className="mw-600">
+      <p>This example should always be offset from the window by at least 45px</p>
+      <Zoom {...props} zoomMargin={45}>
+        <img
+          alt={imgThatWanakaTree.alt}
+          src={imgThatWanakaTree.src}
+          height="320"
+          loading="lazy"
+        />
+      </Zoom>
+    </div>
+  </main>
+)
+
+// =============================================================================
+
 export const SmallPortrait: ComponentStory<typeof Zoom> = (props) => (
   <main aria-label="Story">
     <h1>A portrait image with a small width specified</h1>


### PR DESCRIPTION
## Description

This pull request closes https://github.com/rpearce/react-medium-image-zoom/issues/350 by finally solving the `zoomMargin` math issue.

Has this _ever_ measured correctly? [The same math has been used since v2 >5 years ago](https://github.com/rpearce/react-medium-image-zoom/blob/e9d138d6b521006d8d02e646db7cdfc3dcbb07c2/src/helpers.js#L34-L38).

## Testing

1. Run the storybook examples: `npm start`
2. Go to the `Zoom Margin` story
3. Ensure the zoomed image is offset from the window by the appropriate amount
4. Use a portrait image and see how that works
