### PR TITLE
Fix clicking to unzoom SVG elements

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -244,9 +244,9 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
         />
         : isSvg
           ? <div
-            data-rmiz-modal-img
-            ref={refModalImg}
-            style={this.styleModalImg}
+              data-rmiz-modal-img
+              ref={refModalImg}
+              style={this.styleModalImg}
             />
           : null
 
@@ -611,6 +611,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
       const svg = tmp.firstChild as SVGSVGElement
       svg.style.width = `${styleModalImg.width ?? 0}px`
       svg.style.height = `${styleModalImg.height ?? 0}px`
+      svg.addEventListener('click', this.handleUnzoom)
 
       refModalImg.current?.firstChild?.remove?.()
       refModalImg.current?.appendChild?.(svg)


### PR DESCRIPTION
## Description

This pull request closes https://github.com/rpearce/react-medium-image-zoom/issues/369 by ensuring zoomed SVGs are unzoomed on click.

The logic here, https://github.com/rpearce/react-medium-image-zoom/blob/8cb689aec030cbba19245ae069b10604df809cc0/source/Controlled.tsx#L445, isn't the best thing ever, but it's to try and prevent unzooming if people have customized modal content that somebody clicks on. While I could have it check for an SVG here, `e.target` could potentally be a `<path />` or other SVG sub element, so that isn't a good idea.
