### PR TITLE
Fix: Pressing escape while unzooming

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -533,11 +533,6 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
   }
 
   handleZoomEnd = () => {
-    this.refDialog.current?.addEventListener?.('close', (e) => {
-      e.stopPropagation()
-      e.preventDefault()
-    }, true)
-
     setTimeout(() => {
       this.setState({ modalState: ModalState.LOADED })
       window.addEventListener('resize', this.handleResize, { passive: true })

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -7,6 +7,7 @@ import React, {
   MouseEvent,
   ReactElement,
   ReactNode,
+  SyntheticEvent,
   createRef,
 } from 'react'
 
@@ -135,6 +136,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
 
   render() {
     const {
+      handleDialogCancel,
       handleDialogClick,
       handleDialogKeyDown,
       handleUnzoom,
@@ -295,6 +297,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
             id={idModal}
             onClick={handleDialogClick}
             onClose={handleUnzoom /* eslint-disable-line react/no-unknown-property */}
+            onCancel={handleDialogCancel}
             onKeyDown={handleDialogKeyDown}
             ref={refDialog}
             role="dialog"
@@ -438,6 +441,13 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
 
   handleUnzoom = () => {
     this.props.onZoomChange?.(false)
+  }
+
+  // ===========================================================================
+  // Prevent the browser from removing the dialog on Escape
+
+  handleDialogCancel = (e: SyntheticEvent) => {
+    e.preventDefault()
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Description

This pull request closes https://github.com/rpearce/react-medium-image-zoom/issues/378 by calling `e.preventDefault()` on the `onCancel` `<dialog>` event.

## Testing

1. Run the storybook examples locally
2. Go to the `Custom Modal Styles` one
3. Click it to zoom
4. Click it again to unzoom, but press Escape while it is unzooming
5. Ensure that the unzooming continues smoothly
