### PR TITLE
[BugFix] Image has already been loaded

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -23,6 +23,7 @@ import {
   getStyleModalImg,
   testDiv,
   testImg,
+  testImgLoaded,
   testSvg,
 } from './utils'
 
@@ -430,11 +431,11 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
       .decode()
       .then(setLoaded)
       .catch(() => {
-        if (img.complete) {
-          setLoaded();
-          return;
+        if (testImgLoaded(img)) {
+          setLoaded()
+          return
         }
-        img.onload = setLoaded;
+        img.onload = setLoaded
       })
   }
 

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -429,7 +429,13 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     img
       .decode()
       .then(setLoaded)
-      .catch(() => { img.onload = setLoaded })
+      .catch(() => {
+        if (img.complete) {
+          setLoaded();
+          return;
+        }
+        img.onload = setLoaded;
+      })
   }
 
   // ===========================================================================

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -617,7 +617,13 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
       img
         .decode()
         .then(setLoaded)
-        .catch(() => { img.onload = setLoaded })
+        .catch(() => {
+          if (testImgLoaded(img)) {
+            setLoaded()
+            return
+          }
+          img.onload = setLoaded
+        })
     }
   }
 

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -12,6 +12,7 @@ const testElType: TestElType = (type, el) =>
 
 export const testDiv = (el: unknown): el is HTMLDivElement | HTMLSpanElement => testElType('DIV', el) || testElType('SPAN', el)
 export const testImg = (el: unknown): el is HTMLImageElement => testElType('IMG', el)
+export const testImgLoaded = (el: HTMLImageElement) => el.complete && el.naturalHeight !== 0
 export const testSvg = (el: unknown): el is SVGElement => testElType('SVG', el)
 
 // =============================================================================


### PR DESCRIPTION
## Description

Sometimes the image has already been loaded and it can't trigger the `onload` event. So we should check if the image has been loaded before binding the event, and if it has been loaded, we can call `setLoaded` directly. Otherwise, bind the `onload` event.

## Testing

Take the screenshot as an example:

![image](https://user-images.githubusercontent.com/12215513/210056517-7c066fbd-c65d-4837-bea2-37b4506d2b51.png)

Because `epid4.png` has already been loaded, so the `onload` event doesn't be triggered as expected and the DOM shows `data-rmiz-content="not-found"`.

After my change, it works!

![image](https://user-images.githubusercontent.com/12215513/210056645-5ba11213-5058-4813-aebf-b0f9bdff30fc.png)

Please let me know if any questions.

Thanks.