### PR TITLE
fix(375): NaN invalid CSS width issue

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -638,8 +638,8 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
       tmp.innerHTML = imgEl.outerHTML
 
       const svg = tmp.firstChild as SVGSVGElement
-      svg.style.width = `${styleModalImg.width ?? 0}px`
-      svg.style.height = `${styleModalImg.height ?? 0}px`
+      svg.style.width = `${styleModalImg.width || 0}px`
+      svg.style.height = `${styleModalImg.height || 0}px`
       svg.addEventListener('click', this.handleUnzoom)
 
       refModalImg.current?.firstChild?.remove?.()

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -85,6 +85,10 @@ export const getScale: GetScale = ({
   targetHeight,
   targetWidth,
 }) => {
+  if (!containerHeight || !containerWidth) {
+    return 1
+  }
+
   return !hasScalableSrc && targetHeight && targetWidth
     ? getScaleToWindowMax({
       containerHeight,


### PR DESCRIPTION
## Description

This PR addresses #375

When an element (or it's "container" concept) has a width and/or height of `0`, the `getScale` function tries to do some math that results in `Infinity`. When it then tried to multiply a dimension of `0` by the resulting scale (`Infinity`), it returned `NaN`, so we would end up with values like `{ width: NaN, height: NaN }` that were used in `style` tags on an `<img />`.

To resolve this, if the values for `containerHeight` or `containerWidth` are falsy (e.g. `null`, `undefined`, or `0`) for any reason, we bail from `getScale()` and return a scale of `1`.

## Testing

Here is the simplest possible reproducible case:

1. Clone the project
1. Run `npm i`
1. Run `npm start`
1. Navigate to http://localhost:6006/?path=/story/img--regular
1. Open your JS web console
1. Make this change to this line: https://github.com/rpearce/react-medium-image-zoom/blob/ce1d2d24132592db3ade341740a77ce49b229eff/stories/Img.stories.tsx#L41 with this diff
   ```diff
   diff --git a/stories/Img.stories.tsx b/stories/Img.stories.tsx
   index b3b9598..6825532 100644
   --- a/stories/Img.stories.tsx
   +++ b/stories/Img.stories.tsx
   @@ -38,7 +38,7 @@ export default {
    export const Regular: ComponentStory<typeof Zoom> = (props) => (
      <main aria-label="Story">
        <h1>Zooming a regular image</h1>
   -    <div className="mw-600">
   +    <div className="mw-600" hidden>
          <Zoom {...props}>
            <img
              alt={imgThatWanakaTree.alt}

   ```
1. Observe this error or "hard refresh" the page a time or two
1. `git stash` your change
1. Checkout this branch
1. `git stash pop` your change
1. Note that the error is no longer there

