### PR TITLE
fix(406): SVG missing parent error

### DIFF
--- a/source/utils.ts
+++ b/source/utils.ts
@@ -537,15 +537,25 @@ export const getStyleGhost: GetStyleGhost = (imgEl) => {
   }
 
   if (testSvg(imgEl)) {
-    const parentEl = imgEl.parentNode as HTMLElement
-    const parentRect = parentEl?.getBoundingClientRect?.()
+    const parentEl = imgEl.parentElement
     const rect = imgEl.getBoundingClientRect()
 
-    return {
-      height: rect.height,
-      left: parentRect.left - rect.left,
-      width: rect.width,
-      top: parentRect.top - rect.top,
+    if (parentEl) {
+      const parentRect = parentEl.getBoundingClientRect()
+
+      return {
+        height: rect.height,
+        left: parentRect.left - rect.left,
+        top: parentRect.top - rect.top,
+        width: rect.width,
+      }
+    } else {
+      return {
+        height: rect.height,
+        left: rect.left,
+        width: rect.width,
+        top: rect.top,
+      }
     }
   } else {
     return {


### PR DESCRIPTION
## Description

This PR addresses #406 

This fixes an issue where we were unsafely assuming an SVG's parent element existed, and trying to access a bounding rect property on it failed, for getting the bounding client rect failed silently. In essence, `undefined.left` doesn't work.

The fix is to rely on the `imgEl`'s rect if the parent isn't available.

## Testing

1. Clone this repository
2. Run `npm i`
3. Check out this branch
4. Run `npm start`
5. Test all the SVG examples
6. Ensure a `<div>` example works
7. Ensure a regular `<img />` example works
