### PR TITLE
fix(412): zoom when role=img

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -42,7 +42,7 @@ if (typeof document !== 'undefined') {
 /**
  * The selector query we use to find and track the image
  */
-const IMAGE_QUERY = ['img', 'svg', '[data-zoom]']
+const IMAGE_QUERY = ['img', 'svg', '[role="img"]', '[data-zoom]']
   .map(x => `${x}:not([aria-hidden="true"])`)
   .join(',')
 


### PR DESCRIPTION
## Description

Fixes https://github.com/rpearce/react-medium-image-zoom/issues/412 by 

In a recent bugfix to support older browsers (#402), I accidentally left ouf the `[role="img"]` selector from the DOM query, thereby making `<div role="img">` instances no longer work.

## Testing

1. Clone this repository
2. Run `npm i --no-save`
3. Run `npm start`
4. Go to the Galleries > Div example
5. It should work as expected
