### PR TITLE
chore: cleanup style modal img code

### DIFF
--- a/source/utils.ts
+++ b/source/utils.ts
@@ -460,6 +460,9 @@ export const getStyleModalImg: GetStyleModalImg = ({
   const imgRect = targetEl.getBoundingClientRect()
   const targetElComputedStyle = window.getComputedStyle(targetEl)
 
+  const isDivImg = loadedImgEl != null && testDiv(targetEl)
+  const isImgObjectFit = loadedImgEl != null && !isDivImg
+
   const styleImgRegular = getImgRegularStyle({
     containerHeight: imgRect.height,
     containerLeft: imgRect.left,
@@ -471,7 +474,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
     targetWidth: loadedImgEl?.naturalWidth ?? imgRect.width,
   })
 
-  const styleImgObjectFit = loadedImgEl && targetElComputedStyle.objectFit
+  const styleImgObjectFit = isImgObjectFit
     ? getImgObjectFitStyle({
       containerHeight: imgRect.height,
       containerLeft: imgRect.left,
@@ -486,7 +489,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
     })
     : undefined
 
-  const styleDivImg = loadedImgEl && testDiv(targetEl)
+  const styleDivImg = isDivImg
     ? getDivImgStyle({
       backgroundPosition: targetElComputedStyle.backgroundPosition,
       backgroundSize: targetElComputedStyle.backgroundSize,


### PR DESCRIPTION
## Description

If we know we're working with a `div` image, then there's no need for us to have the `getImgObjectFitStyle(...)` code run. This also ensures that the logic here does indeed return booleans.

## Testing

Not a huge risk here: images should still zoom with object fit cover (for example), and div images should still zoom.
