### PR TITLE
feat(405): add zoomUseBorderRadius feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ export interface UncontrolledProps {
   // be from the window's boundaries.
   // Default: 0
   zoomMargin?: number
+
+  // Indicate that the zoomed image should derive a
+  // border-radius value from the original image.
+  // Default: false
+  zoomUseBorderRadius?: boolean
 }
 ```
 

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -92,6 +92,7 @@ export interface ControlledProps {
   }) => ReactElement
   zoomImg?: ImgHTMLAttributes<HTMLImageElement>
   zoomMargin?: number
+  zoomUseBorderRadius?: boolean
 }
 
 export function Controlled (props: ControlledProps) {
@@ -105,6 +106,7 @@ interface ControlledDefaultProps {
   IconZoom: ElementType
   wrapElement: 'div' | 'span'
   zoomMargin: number
+  zoomUseBorderRadius: boolean
 }
 
 type ControlledPropsWithDefaults = ControlledDefaultProps & ControlledProps
@@ -125,6 +127,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     IconZoom: IEnlarge,
     wrapElement: 'div',
     zoomMargin: 0,
+    zoomUseBorderRadius: false,
   }
 
   state: ControlledState = {
@@ -169,6 +172,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
         ZoomContent,
         zoomImg,
         zoomMargin,
+        zoomUseBorderRadius,
       },
       refContent,
       refDialog,
@@ -237,6 +241,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
         offset: zoomMargin,
         shouldRefresh,
         targetEl: imgEl,
+        zoomUseBorderRadius,
       })
       : {}
 

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -144,8 +144,21 @@ export const getImgAlt: GetImgAlt = (imgEl) => {
 
 // =============================================================================
 
+interface ScaleBorderRadius {
+  (borderRadius: string, scale: number): string
+}
+
+const scaleBorderRadius: ScaleBorderRadius = (borderRadius, scale) => {
+  return borderRadius.endsWith('px')
+    ? parseFloat(borderRadius) * scale + 'px'
+    : borderRadius
+}
+
+// =============================================================================
+
 export interface GetImgRegularStyle {
   (data: {
+    borderRadius: string,
     containerHeight: number,
     containerLeft: number,
     containerTop: number,
@@ -158,6 +171,7 @@ export interface GetImgRegularStyle {
 }
 
 export const getImgRegularStyle: GetImgRegularStyle = ({
+  borderRadius,
   containerHeight,
   containerLeft,
   containerTop,
@@ -182,6 +196,7 @@ export const getImgRegularStyle: GetImgRegularStyle = ({
     width: containerWidth * scale,
     height: containerHeight * scale,
     transform: `translate(0,0) scale(${1 / scale})`,
+    borderRadius: scaleBorderRadius(borderRadius, scale),
   }
 }
 
@@ -206,6 +221,7 @@ export const parsePosition: ParsePosition = ({ position, relativeNum }) => {
 
 export interface GetImgObjectFitStyle {
   (data: {
+    borderRadius: string,
     containerHeight: number,
     containerLeft: number,
     containerTop: number,
@@ -220,6 +236,7 @@ export interface GetImgObjectFitStyle {
 }
 
 export const getImgObjectFitStyle: GetImgObjectFitStyle = ({
+  borderRadius,
   containerHeight,
   containerLeft,
   containerTop,
@@ -266,6 +283,7 @@ export const getImgObjectFitStyle: GetImgObjectFitStyle = ({
       width: targetWidth * ratio * scale,
       height: targetHeight * ratio * scale,
       transform: `translate(0,0) scale(${1 / scale})`,
+      borderRadius: scaleBorderRadius(borderRadius, scale),
     }
   } else if (objectFit === 'none') {
     const [posLeft = '50%', posTop = '50%'] = objectPosition.split(' ')
@@ -287,6 +305,7 @@ export const getImgObjectFitStyle: GetImgObjectFitStyle = ({
       width: targetWidth * scale,
       height: targetHeight * scale,
       transform: `translate(0,0) scale(${1 / scale})`,
+      borderRadius: scaleBorderRadius(borderRadius, scale),
     }
   } else if (objectFit === 'fill') {
     const widthRatio = containerWidth / targetWidth
@@ -306,6 +325,7 @@ export const getImgObjectFitStyle: GetImgObjectFitStyle = ({
       width: containerWidth * scale,
       height: containerHeight * scale,
       transform: `translate(0,0) scale(${1 / scale})`,
+      borderRadius: scaleBorderRadius(borderRadius, scale),
     }
   } else {
     return {}
@@ -318,6 +338,7 @@ export interface GetDivImgStyle {
   (data: {
     backgroundPosition: string,
     backgroundSize: string,
+    borderRadius: string,
     containerHeight: number,
     containerLeft: number,
     containerTop: number,
@@ -332,6 +353,7 @@ export interface GetDivImgStyle {
 export const getDivImgStyle: GetDivImgStyle = ({
   backgroundPosition,
   backgroundSize,
+  borderRadius,
   containerHeight,
   containerLeft,
   containerTop,
@@ -368,6 +390,7 @@ export const getDivImgStyle: GetDivImgStyle = ({
       width: targetWidth * ratio * scale,
       height: targetHeight * ratio * scale,
       transform: `translate(0,0) scale(${1 / scale})`,
+      borderRadius: scaleBorderRadius(borderRadius, scale),
     }
   } else if (backgroundSize === 'auto') {
     const [posLeft = '50%', posTop = '50%'] = backgroundPosition.split(' ')
@@ -389,6 +412,7 @@ export const getDivImgStyle: GetDivImgStyle = ({
       width: targetWidth * scale,
       height: targetHeight * scale,
       transform: `translate(0,0) scale(${1 / scale})`,
+      borderRadius: scaleBorderRadius(borderRadius, scale),
     }
   } else {
     const [sizeW = '50%', sizeH = '50%'] = backgroundSize.split(' ')
@@ -420,6 +444,7 @@ export const getDivImgStyle: GetDivImgStyle = ({
       width: targetWidth * ratio * scale,
       height: targetHeight * ratio * scale,
       transform: `translate(0,0) scale(${1 / scale})`,
+      borderRadius: scaleBorderRadius(borderRadius, scale),
     }
   }
 }
@@ -438,6 +463,7 @@ export interface GetStyleModalImg {
     offset: number,
     shouldRefresh: boolean,
     targetEl: SupportedImage,
+    zoomUseBorderRadius: boolean,
   }): CSSProperties
 }
 
@@ -450,6 +476,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
   offset,
   shouldRefresh,
   targetEl,
+  zoomUseBorderRadius,
 }) => {
   const hasScalableSrc =
     isSvg ||
@@ -459,11 +486,13 @@ export const getStyleModalImg: GetStyleModalImg = ({
 
   const imgRect = targetEl.getBoundingClientRect()
   const targetElComputedStyle = window.getComputedStyle(targetEl)
+  const borderRadius = zoomUseBorderRadius ? targetElComputedStyle.borderRadius : '0'
 
   const isDivImg = loadedImgEl != null && testDiv(targetEl)
   const isImgObjectFit = loadedImgEl != null && !isDivImg
 
   const styleImgRegular = getImgRegularStyle({
+    borderRadius,
     containerHeight: imgRect.height,
     containerLeft: imgRect.left,
     containerTop: imgRect.top,
@@ -476,6 +505,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
 
   const styleImgObjectFit = isImgObjectFit
     ? getImgObjectFitStyle({
+      borderRadius,
       containerHeight: imgRect.height,
       containerLeft: imgRect.left,
       containerTop: imgRect.top,
@@ -493,6 +523,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
     ? getDivImgStyle({
       backgroundPosition: targetElComputedStyle.backgroundPosition,
       backgroundSize: targetElComputedStyle.backgroundSize,
+      borderRadius,
       containerHeight: imgRect.height,
       containerLeft: imgRect.left,
       containerTop: imgRect.top,
@@ -573,5 +604,3 @@ export const getStyleGhost: GetStyleGhost = (imgEl) => {
     }
   }
 }
-
-// =============================================================================

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -444,6 +444,25 @@ export const InlineImage = (props) => (
 )
 
 // =============================================================================
+
+export const UseBorderRadius = (props) => (
+  <main aria-label="Story">
+    <h1>Zooming a regular image</h1>
+    <div className="mw-600">
+      <Zoom {...props} zoomUseBorderRadius={true}>
+        <img
+          alt={imgThatWanakaTree.alt}
+          src={imgThatWanakaTree.src}
+          height="320"
+          loading="lazy"
+          style={{ borderRadius: '4rem' }}
+        />
+      </Zoom>
+    </div>
+  </main>
+)
+
+// =============================================================================
 // INTERACTIONS
 
 export const AutomatedTest = Regular.bind({}, { title: '(Automated Test)' })


### PR DESCRIPTION
## Description

Closes https://github.com/rpearce/react-medium-image-zoom/issues/405

## Testing

1. Clone this repo
2. Run `npm i`
3. Run `npm start`
4. Go to http://localhost:6006/?path=/story/img--use-border-radius
5. Does the border radius "work"?
6. Try this on `<div>` background image examples, too, if you can
