### PR TITLE
chore: remove unused CI step (playwright install)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,6 @@ jobs:
     - name: Install deps without updating package-lock.json
       run: npm i --no-save
 
-    - name: Install Playwright for Storybook
-      run: npx playwright install --with-deps
-
     - name: Run the CI build
       run: npm run ci
 


### PR DESCRIPTION
## Description

Not much to see here. This removes a playwright install from CI steps that was accidentally left in.
