### PR TITLE
fix(421): re-enable body scroll when unmounting

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -338,6 +338,9 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
   }
 
   componentWillUnmount() {
+    if (this.state.modalState !== ModalState.UNLOADED) {
+      this.bodyScrollEnable()
+    }
     this.changeObserver?.disconnect?.()
     this.imgElObserver?.disconnect?.()
     this.imgEl?.removeEventListener?.('load', this.handleImgLoad)


### PR DESCRIPTION
## Description

This pull request addresses https://github.com/rpearce/react-medium-image-zoom/issues/421 by re-enabling body scroll if we're not in an `UNLOADED` state when unmounting.

## Testing

1. Clone this repo
2. Checkout this branch
3. Run `npm i`
4. Run `npm start`
5. In your browser, shrink the browser window so it's really small and go to one of the gallery pages
6. Click on an image so it's zoomed
7. Navigate to another gallery page. You should be able to scroll that page
8. For extra testing, do these same steps with other examples in various states (unzooming, unzoomed, for example)
