### PR TITLE
fix(README) tag is not closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ const CustomZoomContent = ({
         </cite>
       </figcaption>
     </figure>
-  <>
+  </>
 }
 ```
 


### PR DESCRIPTION
### Simple fix to correctly close the tag in one of the examples.

![Screenshot from 2023-11-21 03-04-11](https://github.com/rpearce/react-medium-image-zoom/assets/26748277/fd6e2585-7f11-4968-af7c-3864e1a92714)


