### PR TITLE
chore: try dependabot differently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,31 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
 
   - package-ecosystem: "npm"
+    allow:
+      - dependency-type: "direct"
     directory: "/"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    groups:
+      babel:
+        patterns:
+          - "@babel/*"
+          - "babel-loader"
+      eslint:
+        patterns:
+          - "@typescript-eslint/eslint-plugin"
+          - "@typescript-eslint/parser"
+          - "eslint*"
+      rollup:
+        patterns:
+          - "@rollup/plugin-typescript"
+          - "rollup"
+          - "rollup-plugin-dts"
+      storybook:
+        patterns:
+          - "@storybook/*"
+          - "storybook"


### PR DESCRIPTION
## Description

Not much to see here. This groups some dependabot deps and sets it to only open PRs for ones mentioned in package.json
