### PR TITLE
chore: get better gzip compression via React namespacing

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -1,16 +1,5 @@
-import React, {
-  CSSProperties,
-  Component,
-  ElementType,
-  ImgHTMLAttributes,
-  MouseEvent,
-  ReactElement,
-  ReactNode,
-  SyntheticEvent,
-  createRef,
-} from 'react'
-
-import { createPortal } from 'react-dom'
+import React from 'react'
+import ReactDOM from 'react-dom'
 
 import type { SupportedImage } from './types'
 import { IEnlarge, ICompress } from './icons'
@@ -66,20 +55,20 @@ const defaultBodyAttrs: BodyAttrs = {
 export interface ControlledProps {
   a11yNameButtonUnzoom?: string
   a11yNameButtonZoom?: string
-  children: ReactNode
+  children: React.ReactNode
   classDialog?: string
-  IconUnzoom?: ElementType
-  IconZoom?: ElementType
+  IconUnzoom?: React.ElementType
+  IconZoom?: React.ElementType
   isZoomed: boolean
   onZoomChange?: (value: boolean) => void
   wrapElement?: 'div' | 'span'
   ZoomContent?: (data: {
-    img: ReactElement | null
-    buttonUnzoom: ReactElement<HTMLButtonElement>
+    img: React.ReactElement | null
+    buttonUnzoom: React.ReactElement<HTMLButtonElement>
     modalState: ModalState
     onUnzoom: () => void
-  }) => ReactElement
-  zoomImg?: ImgHTMLAttributes<HTMLImageElement>
+  }) => React.ReactElement
+  zoomImg?: React.ImgHTMLAttributes<HTMLImageElement>
   zoomMargin?: number
 }
 
@@ -90,8 +79,8 @@ export function Controlled (props: ControlledProps) {
 interface ControlledDefaultProps {
   a11yNameButtonUnzoom: string
   a11yNameButtonZoom: string
-  IconUnzoom: ElementType
-  IconZoom: ElementType
+  IconUnzoom: React.ElementType
+  IconZoom: React.ElementType
   wrapElement: 'div' | 'span'
   zoomMargin: number
 }
@@ -106,7 +95,7 @@ interface ControlledState {
   shouldRefresh: boolean
 }
 
-class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledState> {
+class ControlledBase extends React.Component<ControlledPropsWithDefaults, ControlledState> {
   static defaultProps: ControlledDefaultProps = {
     a11yNameButtonUnzoom: 'Minimize image',
     a11yNameButtonZoom: 'Expand image',
@@ -124,18 +113,18 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
     shouldRefresh: false,
   }
 
-  private refContent = createRef<HTMLDivElement>()
-  private refDialog = createRef<HTMLDialogElement>()
-  private refModalContent = createRef<HTMLDivElement>()
-  private refModalImg = createRef<HTMLImageElement>()
-  private refWrap = createRef<HTMLDivElement>()
+  private refContent = React.createRef<HTMLDivElement>()
+  private refDialog = React.createRef<HTMLDialogElement>()
+  private refModalContent = React.createRef<HTMLDivElement>()
+  private refModalImg = React.createRef<HTMLImageElement>()
+  private refWrap = React.createRef<HTMLDivElement>()
 
   private changeObserver: MutationObserver | undefined
   private imgEl: SupportedImage | null = null
   private imgElObserver: ResizeObserver | undefined
   private isScaling = false
   private prevBodyAttrs: BodyAttrs = defaultBodyAttrs
-  private styleModalImg: CSSProperties = {}
+  private styleModalImg: React.CSSProperties = {}
   private touchYStart?: number
   private touchYEnd?: number
 
@@ -209,7 +198,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
 
     // =========================================================================
 
-    const styleContent: CSSProperties = {
+    const styleContent: React.CSSProperties = {
       visibility: modalState === ModalState.UNLOADED ? 'visible' : 'hidden',
     }
 
@@ -292,7 +281,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
             <IconZoom />
           </button>
         </WrapElement>}
-        {hasImage && createPortal(
+        {hasImage && ReactDOM.createPortal(
           <dialog /* eslint-disable-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-redundant-roles */
             aria-labelledby={idModalImg}
             aria-modal="true"
@@ -490,7 +479,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
   /**
    * Prevent the browser from removing the dialog on Escape
    */
-  handleDialogCancel = (e: SyntheticEvent) => {
+  handleDialogCancel = (e: React.SyntheticEvent) => {
     e.preventDefault()
   }
 
@@ -499,7 +488,7 @@ class ControlledBase extends Component<ControlledPropsWithDefaults, ControlledSt
   /**
    *  Have dialog.click() only close in certain situations
    */
-  handleDialogClick = (e: MouseEvent<HTMLDialogElement>) => {
+  handleDialogClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     if (e.target === this.refModalContent.current || e.target === this.refModalImg.current) {
       this.handleUnzoom()
     }

--- a/source/Uncontrolled.tsx
+++ b/source/Uncontrolled.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Controlled, ControlledProps } from './Controlled'
 
 // =============================================================================
@@ -7,7 +7,7 @@ export type UncontrolledProps =
   Omit<ControlledProps, 'isZoomed' | 'onZoomChange'>
 
 export function Uncontrolled (props: UncontrolledProps) {
-  const [isZoomed, setIsZoomed] = useState(false)
+  const [isZoomed, setIsZoomed] = React.useState(false)
 
   return <Controlled {...props} isZoomed={isZoomed} onZoomChange={setIsZoomed} />
 }

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react'
+import React from 'react'
 import type { SupportedImage } from './types'
 
 // =============================================================================
@@ -154,7 +154,7 @@ export interface GetImgRegularStyle {
     offset: number,
     targetHeight: number,
     targetWidth: number,
-  }): CSSProperties
+  }): React.CSSProperties
 }
 
 export const getImgRegularStyle: GetImgRegularStyle = ({
@@ -216,7 +216,7 @@ export interface GetImgObjectFitStyle {
     offset: number,
     targetHeight: number,
     targetWidth: number,
-  }): CSSProperties
+  }): React.CSSProperties
 }
 
 export const getImgObjectFitStyle: GetImgObjectFitStyle = ({
@@ -326,7 +326,7 @@ export interface GetDivImgStyle {
     offset: number,
     targetHeight: number,
     targetWidth: number,
-  }): CSSProperties
+  }): React.CSSProperties
 }
 
 export const getDivImgStyle: GetDivImgStyle = ({
@@ -438,7 +438,7 @@ export interface GetStyleModalImg {
     offset: number,
     shouldRefresh: boolean,
     targetEl: SupportedImage,
-  }): CSSProperties
+  }): React.CSSProperties
 }
 
 export const getStyleModalImg: GetStyleModalImg = ({
@@ -535,7 +535,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
 // =============================================================================
 
 export interface GetStyleGhost {
-  (imgEl: SupportedImage | null): CSSProperties
+  (imgEl: SupportedImage | null): React.CSSProperties
 }
 
 export const getStyleGhost: GetStyleGhost = (imgEl) => {

--- a/stories/Galleries.stories.tsx
+++ b/stories/Galleries.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import type { Meta } from '@storybook/react'
 
 import Zoom from '../source'
@@ -42,7 +42,7 @@ export const ImageGallery = () => {
   const [objectFit, setObjectFit] = useState('cover' as ObjectFit)
   const [objectPosition, setObjectPosition] = useState('50% 50%')
 
-  const handleSubmit = useCallback((e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     const data = new FormData(e.currentTarget)
@@ -132,7 +132,7 @@ export const DivImageGallery = () => {
   const [bgPosition, setBgPosition] = useState('50%')
   const [aspectRatio, setAspectRatio] = useState('56%')
 
-  const handleSubmit = useCallback((e: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     const data = new FormData(e.currentTarget)


### PR DESCRIPTION
## Description

This clears up some "what API does this even come from?" questions and also has the added benefit of better gzip compression due to the repeated strings and not requiring extra variables for destructured objects.

## Test results

```
# Before
orig: 15144 bytes
gzip: 4518 bytes

# After
orig: 15165 bytes
gzip: 4509 bytes
```