### PR TITLE
fix: clicking image before it loads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Use nodejs
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install deps without updating package-lock.json

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import ts from '@rollup/plugin-typescript'
 import dts from 'rollup-plugin-dts'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 
 export default (async () => ([
   {

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -184,9 +184,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
 
     const hasZoomImg = !!zoomImg?.src
 
-    const hasImage = imgEl &&
-      (loadedImgEl || isSvg) &&
-      window.getComputedStyle(imgEl).display !== 'none'
+    const hasImage = this.hasImage()
 
     const labelBtnZoom = imgAlt
       ? `${a11yNameButtonZoom}: ${imgAlt}`
@@ -220,7 +218,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
         loadedImgEl,
         offset: zoomMargin,
         shouldRefresh,
-        targetEl: imgEl,
+        targetEl: imgEl as SupportedImage,
       })
       : {}
 
@@ -470,7 +468,9 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
    * Report that zooming should occur
    */
   handleZoom = () => {
-    this.props.onZoomChange?.(true)
+    if (this.hasImage()) {
+      this.props.onZoomChange?.(true)
+    }
   }
 
   /**
@@ -599,6 +599,15 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
   }
 
   // ===========================================================================
+
+  /**
+   * Check if we have a loaded image to work with
+   */
+  hasImage = () => {
+    return this.imgEl &&
+      (this.state.loadedImgEl || testSvg(this.imgEl)) &&
+      window.getComputedStyle(this.imgEl).display !== 'none'
+  }
 
   /**
    * Perform zooming actions


### PR DESCRIPTION
## Description

Fixes #470 by only allowing zooming when we have a loaded image.

## Testing

1. Checkout this branch
2. Run `npm start`
3. Go to http://localhost:6006/iframe.html?args=&id=img--inline-image&viewMode=story in Chrome
4. Open the Network tab and choose "Fast 3G" for throttling
5. Hard-refresh the page to force an image re-download
6. When the image starts loading in, start clicking on it. Nothing should happen. When it has loaded, the zooming behavior should more or less work
