### PR TITLE
fix: weird state where wheel event fires too early

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -619,7 +619,6 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     this.setState({ modalState: ModalState.LOADING })
     this.loadZoomImg()
 
-    window.addEventListener('wheel', this.handleWheel, { passive: true })
     window.addEventListener('touchstart', this.handleTouchStart, { passive: true })
     window.addEventListener('touchmove', this.handleTouchMove, { passive: true })
     window.addEventListener('touchend', this.handleTouchEnd, { passive: true })
@@ -637,6 +636,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     setTimeout(() => {
       this.setState({ modalState: ModalState.LOADED })
       window.addEventListener('resize', this.handleResize, { passive: true })
+      window.addEventListener('wheel', this.handleWheel, { passive: true })
     }, 0)
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/rpearce/react-medium-image-zoom/issues/439

If someone is using a mouse with a scroll wheel in Windows using Chrome or Edge, and they click to zoom an image while the scroll wheel is still going, they would end up in an intermediary, broken state.

This fixes the issue by ensuring that the `wheel` event, which is used for closing the zoomed image dialog, isn't able to be triggered until the image has zoomed fully.

## Testing

I repro'd this issue using Parallels and doing what was described above (and is also shown in a video on the issue).
