### PR TITLE
fix: flickering after unzooming

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -669,11 +669,10 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
       this.setState({
         shouldRefresh: false,
         modalState: ModalState.UNLOADED,
+      }, () => {
+        this.refDialog.current?.close?.()
+        this.bodyScrollEnable()
       })
-
-      this.refDialog.current?.close?.()
-
-      this.bodyScrollEnable()
     }, 0)
   }
 


### PR DESCRIPTION
## Description

Fixes a weird, doesn't-always-happen little flicker when an image is unzoomed. It's particularly noticeable if a page takes up a bunch of memory, and it's more reproducible in Safari in that scenario.

This moves the official closing of the `<dialog>` element and re-enabling of body scroll until after the `setState` gets a change to run. I think the issue is that the React internals would sometimes take too long, and we'd remove the dialog before the component had a chance to update and know that it was an `UNLOADED` `modalState`, thus having the original image still with `visibility: hidden;` for a split second before coming back.
