### PR TITLE
fix: ghost not being styled right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "5.2.7",
+  "version": "5.2.8-beta.0",
   "license": "BSD-3-Clause",
   "description": "Accessible medium.com-style image zoom for React",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-medium-image-zoom",
-  "version": "5.2.8-beta.0",
+  "version": "5.2.7",
   "license": "BSD-3-Clause",
   "description": "Accessible medium.com-style image zoom for React",
   "type": "module",

--- a/source/styles.css
+++ b/source/styles.css
@@ -1,6 +1,3 @@
-[data-rmiz] {
-  position: relative;
-}
 [data-rmiz-ghost] {
   position: absolute;
   pointer-events: none;

--- a/stories/base.css
+++ b/stories/base.css
@@ -59,9 +59,16 @@ img {
 }
 .change-icons [data-rmiz-btn-zoom],
 .change-icons [data-rmiz-btn-unzoom] {
+  align-items: center;
   background-color: #fff;
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.8);
   color: #000;
+  display: flex;
+  font-family: monospace;
+  font-size: 2rem;
+  height: 3rem;
+  justify-content: center;
+  width: 3rem;
 }
 .custom-zoom [data-rmiz-modal-overlay],
 .custom-zoom [data-rmiz-modal-img] {


### PR DESCRIPTION
## Description

This pull request closes https://github.com/rpearce/react-medium-image-zoom/issues/627, and the only real commit to look at is https://github.com/rpearce/react-medium-image-zoom/pull/638/commits/302ed09553b60e1a054e544180e7c271679f64dd.

This was a weird one. I don't know how the ghost element is working correctly in Chrome & Firefox, but in Safari, `[data-rmiz]` having `position: relative;` makes its ghost child, which is `position: absolute;` be offset quite a bit, and it's even worse the longer a page is. It may only surface when people use `<Zoom wrapElement="span" ...>`, and the parent element goes to being `inline`.

A quick solution is to simply remove that style, but I noticed that there was some funkyness & inconsistency with how the ghost rendered in a few situations. Instead of trying to get the ghost's styles _before_ we render (which I knew was unwise, but I did it anyway), this work moves that to a more after-the-render way of doing things. It also takes into account pretty much any change that can happen to the `<Zoom>` children now.

## Testing

The main thing to test here is that the `data-rmiz-ghost=""` element's dimensions always exactly matches that of the zoomable element content (_note: that isn't true for image elements with different `object-fit` values, though that wouldn't be that hard, given we already can zoom from those correctly..._).

<img width="576" alt="imagen" src="https://github.com/user-attachments/assets/b55d53d8-748f-4e28-b9a7-50b920701c51">

