### PR TITLE
fix: unzooming getting stuck in Safari

### DIFF
--- a/.changeset/bright-snakes-laugh.md
+++ b/.changeset/bright-snakes-laugh.md
@@ -1,0 +1,5 @@
+---
+"react-medium-image-zoom": patch
+---
+
+fix unzooming getting stuck in Safari


### PR DESCRIPTION
## Description

This solves an issue where Safari is unreliable with when it's going to call `transitionend` events when significant memory is being used on a webpage. Additionally, it does the following:

* refactors the state change events to be handled together after `componentDidUpdate`
* uses a single `transitionend` event handler to cover both the zoom and unzoom transition ending events
* critically, it adds a timeout event that takes the original transition duration, plus 50ms, and runs a function that ensures the transition end callback runs; this callback is responsible for resetting the modal state, and that re-enables body scrolling and closes the modal

