### PR TITLE
fix: include 'use client' directive in ESM output

### DIFF
--- a/.changeset/good-mangos-unite.md
+++ b/.changeset/good-mangos-unite.md
@@ -1,0 +1,5 @@
+---
+"react-medium-image-zoom": patch
+---
+
+include 'use client' directive in esm output

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import pkg from './package.json' with { type: 'json' }
 export default (async () => ([
   {
     input: './source/index.ts',
-    output: { file: pkg.main, format: 'es' },
+    output: { file: pkg.main, format: 'es', banner: `'use client';` },
     external: isExternal,
     plugins: [ts({
       tsconfig: './tsconfig.json',


### PR DESCRIPTION
## Description

Fixes https://github.com/rpearce/react-medium-image-zoom/issues/623 by including `'use client';` at the top of the exported ESM file.

<img width="421" alt="" src="https://github.com/user-attachments/assets/66dba764-32de-474f-9662-cb3fc74e3aaa">


## Testing

1. Clone the repo and `cd` into it
2. `git switch fix/use-client`
3. `npm i --no-save`
4. `npm run build`
5. `cat dist/index.js` — this should have `'use client';` at the top
