### PR TITLE
Add Hide Unzoom Button prop to hide unzoom button

### DIFF
--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -61,13 +61,14 @@ export interface ControlledProps {
   classDialog?: string
   IconUnzoom?: React.ElementType
   IconZoom?: React.ElementType
+  hideUnzoomIcon?: boolean
   isZoomed: boolean
   onZoomChange?: (value: boolean) => void
   swipeToUnzoomThreshold?: number
   wrapElement?: 'div' | 'span'
   ZoomContent?: (data: {
     img: React.ReactElement | null
-    buttonUnzoom: React.ReactElement<HTMLButtonElement>
+    buttonUnzoom: React.ReactElement<HTMLButtonElement> | null
     modalState: ModalState
     onUnzoom: () => void
   }) => React.ReactElement
@@ -85,6 +86,7 @@ interface ControlledDefaultProps {
   canSwipeToUnzoom: boolean
   IconUnzoom: React.ElementType
   IconZoom: React.ElementType
+  hideUnzoomIcon: boolean
   swipeToUnzoomThreshold: number
   wrapElement: 'div' | 'span'
   zoomMargin: number
@@ -108,6 +110,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     canSwipeToUnzoom: true,
     IconUnzoom: ICompress,
     IconZoom: IEnlarge,
+    hideUnzoomIcon: false,
     swipeToUnzoomThreshold: 10,
     wrapElement: 'div',
     zoomMargin: 0,
@@ -255,14 +258,18 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
             />
           : null
 
-      const modalBtnUnzoom = <button
-        aria-label={a11yNameButtonUnzoom}
-        data-rmiz-btn-unzoom=""
-        onClick={handleBtnUnzoomClick}
-        type="button"
-      >
-        <IconUnzoom />
-      </button>
+      const modalBtnUnzoom = this.props.hideUnzoomIcon
+        ? null
+        : (
+          <button
+            aria-label={a11yNameButtonUnzoom}
+            data-rmiz-btn-unzoom=""
+            onClick={handleBtnUnzoomClick}
+            type="button"
+        >
+            <IconUnzoom />
+          </button>
+          )
 
       modalContent = ZoomContent
         ? <ZoomContent

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -637,6 +637,27 @@ export const SwipeToUnzoomThreshold = (props: typeof Zoom) => (
 )
 
 // =============================================================================
+
+export const HideUnzoomButton = (props: typeof Zoom) => {
+  return (
+    <main aria-label="Story">
+      <h1>Zooming a regular image</h1>
+      <div className="mw-600" style={{ display: 'flex', flexDirection: 'column' }}>
+        <Zoom {...props} hideUnzoomIcon wrapElement="span">
+          <img
+            alt={imgThatWanakaTree.alt}
+            src={imgThatWanakaTree.src}
+            height="320"
+            decoding="async"
+            loading="lazy"
+          />
+        </Zoom>
+      </div>
+    </main>
+  )
+}
+
+// =============================================================================
 // INTERACTIONS
 
 export const AutomatedTest = Regular.bind({}, { title: '(Automated Test)' })


### PR DESCRIPTION
## Description

Add the possibility of hiding the unzoom button.

## Motivation

I don't want to show the unzoom button because the user clicks on the image to unzoom the image.

## Testing

1. Open storybook
2. Go to <img>
3. Go to Hide Unzoom Button
4. Click on image
5. Check if the image display in the modal and the unzoom button is not visible
