### PR TITLE
fix: zooming inside a parent dialog that has a close handler

### DIFF
--- a/.changeset/flat-readers-return.md
+++ b/.changeset/flat-readers-return.md
@@ -1,0 +1,5 @@
+---
+"react-medium-image-zoom": patch
+---
+
+fix zooming inside a parent dialog that has a close handler

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -145,6 +145,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
       handleBtnUnzoomClick,
       handleDialogCancel,
       handleDialogClick,
+      handleDialogClose,
       handleUnzoom,
       handleZoom,
       imgEl,
@@ -299,7 +300,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
             data-rmiz-modal=""
             id={idModal}
             onClick={handleDialogClick}
-            onClose={handleUnzoom}
+            onClose={handleDialogClose}
             onCancel={handleDialogCancel}
             ref={refDialog}
             role="dialog"
@@ -560,6 +561,16 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
       e.stopPropagation()
       this.handleUnzoom()
     }
+  }
+
+  // ===========================================================================
+
+  /**
+   *  Prevent dialog's close event from closing a parent modal
+   */
+  handleDialogClose = (e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.stopPropagation()
+    this.handleUnzoom()
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Description

Closes https://github.com/rpearce/react-medium-image-zoom/issues/746

I added all the deps from https://stackblitz.com/edit/vitejs-vite-djxwwz?file=src%2FApp.tsx,package.json and set up a Storybook demo that recreated the issue. I then tried a few things and realized that the zoom component's `<dialog>`'s `close` event firing was what was causing the issue with this specific library, so stopping our `close` event propagation is the fix here.
