### PR TITLE
Add prop zoomAlignmentY to control zoomed image vertical alignment relative to the viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ export interface UncontrolledProps {
   // be from the window's boundaries.
   // Default: 0
   zoomMargin?: number
+
+  // Align the zoomed image vertically to the top or center of the viewport.
+  // Default: 'center'
+  zoomAlignmentY?: 'center' | 'top'
 }
 ```
 

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -73,6 +73,7 @@ export interface ControlledProps {
   }) => React.ReactElement
   zoomImg?: React.ImgHTMLAttributes<HTMLImageElement>
   zoomMargin?: number
+  zoomAlignment?: 'center' | 'top'
 }
 
 export function Controlled (props: ControlledProps) {
@@ -88,6 +89,7 @@ interface ControlledDefaultProps {
   swipeToUnzoomThreshold: number
   wrapElement: 'div' | 'span'
   zoomMargin: number
+  zoomAlignment: 'center' | 'top'
 }
 
 type ControlledPropsWithDefaults = ControlledDefaultProps & ControlledProps
@@ -111,6 +113,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     swipeToUnzoomThreshold: 10,
     wrapElement: 'div',
     zoomMargin: 0,
+    zoomAlignment: 'center'
   }
 
   state: ControlledState = {
@@ -161,6 +164,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
         ZoomContent,
         zoomImg,
         zoomMargin,
+        zoomAlignment
       },
       refContent,
       refDialog,
@@ -227,6 +231,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
         offset: zoomMargin,
         shouldRefresh,
         targetEl: imgEl as SupportedImage,
+        zoomAlignment
       })
       : {}
 

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -73,7 +73,7 @@ export interface ControlledProps {
   }) => React.ReactElement
   zoomImg?: React.ImgHTMLAttributes<HTMLImageElement>
   zoomMargin?: number
-  zoomAlignment?: 'center' | 'top'
+  zoomAlignmentY?: 'center' | 'top'
 }
 
 export function Controlled (props: ControlledProps) {
@@ -89,7 +89,7 @@ interface ControlledDefaultProps {
   swipeToUnzoomThreshold: number
   wrapElement: 'div' | 'span'
   zoomMargin: number
-  zoomAlignment: 'center' | 'top'
+  zoomAlignmentY: 'center' | 'top'
 }
 
 type ControlledPropsWithDefaults = ControlledDefaultProps & ControlledProps
@@ -113,7 +113,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     swipeToUnzoomThreshold: 10,
     wrapElement: 'div',
     zoomMargin: 0,
-    zoomAlignment: 'center'
+    zoomAlignmentY: 'center'
   }
 
   state: ControlledState = {
@@ -164,7 +164,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
         ZoomContent,
         zoomImg,
         zoomMargin,
-        zoomAlignment
+        zoomAlignmentY
       },
       refContent,
       refDialog,
@@ -231,7 +231,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
         offset: zoomMargin,
         shouldRefresh,
         targetEl: imgEl as SupportedImage,
-        zoomAlignment
+        zoomAlignmentY
       })
       : {}
 

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -522,19 +522,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
 
     const translateX = viewportX - childCenterX
     const translateY = zoomAlignment === 'center' ? viewportY - childCenterY : -style.top
-
-    console.log('zoomAlignment',zoomAlignment);
-    console.log('viewportY',viewportY)
-    console.log('childCenterY',childCenterY);
-    console.log('translateY',translateY);
-    console.log('-style.top',-style.top)
-
-    /**
-     * translateY current: -106
-     * translateY needed: -253
-     * */
-
-
+    
     // For scenarios like resizing the browser window
     if (shouldRefresh) {
       style.transitionDuration = '0.01ms'

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -438,6 +438,7 @@ export interface GetStyleModalImg {
     offset: number,
     shouldRefresh: boolean,
     targetEl: SupportedImage,
+    zoomAlignment: 'top' | 'center'
   }): React.CSSProperties
 }
 
@@ -450,6 +451,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
   offset,
   shouldRefresh,
   targetEl,
+  zoomAlignment
 }) => {
   const hasScalableSrc =
     isSvg ||
@@ -519,7 +521,19 @@ export const getStyleModalImg: GetStyleModalImg = ({
     const childCenterY = parseFloat(String(style.top || 0)) + (parseFloat(String(style.height || 0)) / 2)
 
     const translateX = viewportX - childCenterX
-    const translateY = viewportY - childCenterY
+    const translateY = zoomAlignment === 'center' ? viewportY - childCenterY : -style.top
+
+    console.log('zoomAlignment',zoomAlignment);
+    console.log('viewportY',viewportY)
+    console.log('childCenterY',childCenterY);
+    console.log('translateY',translateY);
+    console.log('-style.top',-style.top)
+
+    /**
+     * translateY current: -106
+     * translateY needed: -253
+     * */
+
 
     // For scenarios like resizing the browser window
     if (shouldRefresh) {

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -438,7 +438,7 @@ export interface GetStyleModalImg {
     offset: number,
     shouldRefresh: boolean,
     targetEl: SupportedImage,
-    zoomAlignment: 'top' | 'center'
+    zoomAlignmentY: 'top' | 'center'
   }): React.CSSProperties
 }
 
@@ -451,7 +451,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
   offset,
   shouldRefresh,
   targetEl,
-  zoomAlignment
+  zoomAlignmentY
 }) => {
   const hasScalableSrc =
     isSvg ||
@@ -521,8 +521,8 @@ export const getStyleModalImg: GetStyleModalImg = ({
     const childCenterY = parseFloat(String(style.top || 0)) + (parseFloat(String(style.height || 0)) / 2)
 
     const translateX = viewportX - childCenterX
-    const translateY = zoomAlignment === 'center' ? viewportY - childCenterY : -style.top
-    
+    const translateY = zoomAlignmentY === 'center' ? viewportY - childCenterY : -style.top
+
     // For scenarios like resizing the browser window
     if (shouldRefresh) {
       style.transitionDuration = '0.01ms'


### PR DESCRIPTION
## Description

This pull request add a prop to <Controlled/> and <Uncontrolled/> component `zoomAlignmentY`
this props allow to control the zoomed image vertical alignment relative to the viewport; it defaults to `center` to keep the standard behavior consistent, but add also the option `top` to align the image to the viewport top
This is especially useful when used together with prop `ZoomContent` and showing some additional content along the image when zoomed, for instance an extended image description: aligning the zoomed image to top leave a lot more viewport space available

## Testing

1. Create a <Controlled/> or <Uncontrolled/> wrapped element
2. add the prop `<Controlled zoomAlignmentY='top'>[...]</ Controlled>`
3. Click on any image to zoom
4. Image should be aligned to viewport's top edge
5. to test the defaults, just create an element normallly without setting `zoomAlignmentY` and it should align to center as asual
