### PR TITLE
Feat: Add `disabled` prop and `isZoomImageLoaded` to ZoomContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ export interface UncontrolledProps {
   // be from the window's boundaries.
   // Default: 0
   zoomMargin?: number
+
+  // Disables the zoom/unzoom behavior
+  disabled?: boolean
 }
 ```
 
@@ -285,6 +288,7 @@ const CustomZoomContent = ({
   buttonUnzoom, // default unzoom button
   modalState,   // current state of the zoom modal: UNLOADED, LOADING, LOADED, UNLOADING
   img,          // your image, prepped for zooming
+  isZoomImageLoaded // state to check if zoom img is loaded (useful to show loading)
   //onUnzoom,   // unused here, but a callback to manually unzoom the image and
                 //   close the modal if you want to use your own buttons or
                 //   listeners in your custom experience

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -65,10 +65,12 @@ export interface ControlledProps {
   onZoomChange?: (value: boolean) => void
   swipeToUnzoomThreshold?: number
   wrapElement?: 'div' | 'span'
+  disabled?: boolean;
   ZoomContent?: (data: {
     img: React.ReactElement | null
     buttonUnzoom: React.ReactElement<HTMLButtonElement>
-    modalState: ModalState
+    modalState: ModalState,
+    isZoomImageLoaded: boolean,
     onUnzoom: () => void
   }) => React.ReactElement
   zoomImg?: React.ImgHTMLAttributes<HTMLImageElement>
@@ -88,6 +90,7 @@ interface ControlledDefaultProps {
   swipeToUnzoomThreshold: number
   wrapElement: 'div' | 'span'
   zoomMargin: number
+  disabled?: boolean
 }
 
 type ControlledPropsWithDefaults = ControlledDefaultProps & ControlledProps
@@ -111,6 +114,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     swipeToUnzoomThreshold: 10,
     wrapElement: 'div',
     zoomMargin: 0,
+    disabled: false,
   }
 
   state: ControlledState = {
@@ -273,6 +277,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
             buttonUnzoom={modalBtnUnzoom}
             modalState={modalState}
             img={modalImg}
+            isZoomImageLoaded={isZoomImgLoaded}
             onUnzoom={handleUnzoom}
           />
         : <>{modalImg}{modalBtnUnzoom}</>
@@ -523,7 +528,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
    * Report that zooming should occur
    */
   handleZoom = () => {
-    if (this.hasImage()) {
+    if (this.hasImage() && !this.props?.disabled) {
       this.props.onZoomChange?.(true)
     }
   }
@@ -532,6 +537,10 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
    * Report that unzooming should occur
    */
   handleUnzoom = () => {
+    if (this.props.disabled) {
+      return
+    }
+
     this.props.onZoomChange?.(false)
   }
 


### PR DESCRIPTION
## Description
Introduce a `disabled` prop to prevent zoom and unzoom actions, allowing conditional disabling of the zoom functionality.

Pass an `isZoomImageLoaded` boolean to the `ZoomContent` render prop. This enables to render custom loading states or content within the zoom modal while the image is loading.

I was working on my personal project in Next.js and I used the [image-zoom](https://www.kibo-ui.com/components/image-zoom) component from kibo-ui. But I faced 2 issues

- I wanted to disabled zooming behavior, but was not able to, even after using Controlled component. So I added a `disabled` prop that disables the zooming behavior.
- I wanted to show loading animation cause my `zoomImg.src` resolution is higher than `imgSrc`. So I passed `isZoomImageLoaded` to `ZoomContent` so I render an animation while image is being loaded.

You can pick either feature or both, or pick neither, I have created a patch in my repo, but I thought it would be good to open a PR and get review

Video showing both loading and disabled zoom behavior 
[Screencast from 2025-07-14 10-29-07.webm](https://github.com/user-attachments/assets/02af38df-3009-454d-b8ed-e5648c3961cf)


## Testing

### Testing disabled prop
1. Create a `disabled` state by default `false`
`const [disabled, setDisabled] = useState(false)`
3. Create a button to toggle `disabled` state
`<button onClick={() => setDisabled(!disabled)}></button>`
5. Zoom modal should not open when `disabled` state is true

### Testing loading animation
1. Pass `zoomImg.src` of a higher resolution image
2.  Created and pass custom `ZoomContent` component
```

function ZoomContent({
  img,
  isZoomImageLoaded,
}: {
  img: React.ReactElement | null;
  isZoomImageLoaded: boolean;
}) {
  return (
    <>
      {img}
      {!isZoomImageLoaded && (
        <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%,-50%)">
          Loading...
        </div>
      )}
    </>
  );
}
```
3. You should see `Loading...` in the center of the screen until `zoomImg` is loaded.
4. After image is loaded, `Loading...` should be removed 


