### PR TITLE
ZoomImg loading storybook example

### DIFF
--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -216,6 +216,10 @@ export const ZoomImgLoader = (props: typeof Zoom) => (
         <code>isZoomImgLoaded</code> prop to display a loading spinner while the
         high-resolution image is being downloaded.
       </p>
+      <p>
+        Here the loading spinner is shown on every zoom, but in real-world case
+        the browser caches the image, so you&apos;ll only see the loader at first load
+      </p>
       <Zoom
         {...props}
         zoomImg={{
@@ -226,6 +230,39 @@ export const ZoomImgLoader = (props: typeof Zoom) => (
       >
         <img alt={imgKeaSmall.alt} src={imgKeaSmall.src} width="150" />
       </Zoom>
+      <p>
+        Here&apos;s the zoom component with loading spinner
+      </p>
+      <pre>
+        <code>
+          {`
+const CustomZoomContent: UncontrolledProps['ZoomContent'] = ({
+  img,
+  isZoomImgLoaded,
+}) => {
+  return (
+    <>
+      {img}
+      {!isZoomImgLoaded && (
+        <div className='loader-wrapper'>
+          <div className='loader' />
+        </div>
+      )}
+    </>
+  )
+}
+
+<Zoom
+  zoomImg={{
+    src: 'higher-res-image.jpg',
+  }}
+  ZoomContent={CustomZoomContent}
+>
+  <img src='low-res-image.jpg' width="150" />
+</Zoom>
+          `}
+        </code>
+      </pre>
     </div>
   </main>
 )

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -170,6 +170,68 @@ export const ProvideZoomImg = (props: typeof Zoom) => (
 
 // =============================================================================
 
+const CustomZoomContentWithLoader: UncontrolledProps['ZoomContent'] = ({
+  img,
+  isZoomImgLoaded,
+  modalState,
+}) => {
+  const [
+    showLoader,
+    setShowLoader,
+  ] = React.useState(!isZoomImgLoaded)
+
+  /**
+   * Delay the loader so the loading spinner is noticeable
+   */
+  React.useEffect(() => {
+    if (modalState === 'LOADING') {
+      setShowLoader(true)
+      if (isZoomImgLoaded) {
+        setTimeout(() => setShowLoader(false), 1000)
+      }
+    }
+  }, [isZoomImgLoaded, modalState])
+
+  return (
+    <>
+      {img}
+      {showLoader && (
+        <div className='zoom-img-loader-wrapper'>
+          <div className='zoom-img-loader' />
+        </div>
+      )}
+    </>
+  )
+}
+
+export const ZoomImgLoader = (props: typeof Zoom) => (
+  <main aria-label="Story">
+    <h1>
+      ZoomImg with Loading State
+    </h1>
+    <div className="mw-600">
+      <p>
+        This example shows how to provide loading feedback when using a high-resolution&nbsp;
+        <code>zoomImg</code>. The <code>ZoomContent</code> component uses the&nbsp;
+        <code>isZoomImgLoaded</code> prop to display a loading spinner while the
+        high-resolution image is being downloaded.
+      </p>
+      <Zoom
+        {...props}
+        zoomImg={{
+          alt: imgKeaLarge.alt,
+          src: imgKeaLarge.src,
+        }}
+        ZoomContent={CustomZoomContentWithLoader}
+      >
+        <img alt={imgKeaSmall.alt} src={imgKeaSmall.src} width="150" />
+      </Zoom>
+    </div>
+  </main>
+)
+
+// =============================================================================
+
 export const SmallSrcSize = (props: typeof Zoom) => (
   <main aria-label="Story">
     <h1>An image with a small size</h1>

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -231,7 +231,7 @@ export const ZoomImgLoader = (props: typeof Zoom) => (
         <img alt={imgKeaSmall.alt} src={imgKeaSmall.src} width="150" />
       </Zoom>
       <p>
-        Here&apos;s the zoom component with loading spinner
+        Zoom component with loading spinner
       </p>
       <pre>
         <code>

--- a/stories/base.css
+++ b/stories/base.css
@@ -126,6 +126,24 @@ img {
   margin-top: 1.5rem;
 }
 .zoom-caption-link {
-   color: #fff;
-   text-underline-offset: 0.5rem;
+  color: #fff;
+  text-underline-offset: 0.5rem;
+}
+.zoom-img-loader-wrapper {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, 50%);
+}
+.zoom-img-loader {
+  width: 32px;
+  height: 32px;
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top: 3px solid #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }


### PR DESCRIPTION
## Description
This PR adds a story under `img` in the story book. Showing user how to add loading spinner with the help of `ZoomContent` when a `ZoomImg` is provided. The loader was barely noticeble cause the the image get's loaded and cached very quickly. So I added a `useEffect` which delays the loader to 1 second.  The loading spinner is shown everytime the img is zoomed. But in a real-world scenario the loader is shown only once (browser caches the image for next time)

<img width="971" height="996" alt="image" src="https://github.com/user-attachments/assets/a1f36a22-56cf-4f26-aae6-13cdecb640aa" />

## Testing
1. Start the story book server `pnpm run storybook`
2. Go to `http://localhost:6006/?path=/story/img--zoom-img-loader`
3. You should see an example
4. Zoom the image you should see a loading spinner
5. Spinner should render everytime `ZoomImgModal` loads
