### PR TITLE
fix: ensure open modal has pointer-events to fix 3rd party probs

### DIFF
--- a/.changeset/fluffy-rocks-burn.md
+++ b/.changeset/fluffy-rocks-burn.md
@@ -1,0 +1,5 @@
+---
+"react-medium-image-zoom": patch
+---
+
+ensure open modal has pointer-events to fix 3rd party probs

--- a/source/styles.css
+++ b/source/styles.css
@@ -62,6 +62,7 @@
   border: 0;
   background: transparent;
   overflow: hidden;
+  pointer-events: all;
 }
 [data-rmiz-modal-overlay] {
   position: absolute;


### PR DESCRIPTION
## Description

I found, while trying to figure out https://github.com/rpearce/react-medium-image-zoom/discussions/910, that some 3rd party UIs (Radix, here) can disable `pointer-events` for one reason for another, making the zoomed image modal not respond to clicks.

This adds 1 line of CSS to ensure that, when the zoomed modal is `[open]`, `pointer-events` is set to `all`.
