### PR TITLE
fix: prevent zoom click even propagation

### DIFF
--- a/.changeset/chilly-months-win.md
+++ b/.changeset/chilly-months-win.md
@@ -1,5 +1,0 @@
----
-"react-medium-image-zoom": patch
----
-
-prevent default and stop propagation of zoom click event (closes #939)

--- a/.changeset/chilly-months-win.md
+++ b/.changeset/chilly-months-win.md
@@ -1,0 +1,5 @@
+---
+"react-medium-image-zoom": patch
+---
+
+prevent default and stop propagation of zoom click event (closes #939)

--- a/.changeset/red-dingos-know.md
+++ b/.changeset/red-dingos-know.md
@@ -2,4 +2,4 @@
 "react-medium-image-zoom": minor
 ---
 
-Add support for onZoomChange reporting to Uncontrolled components and include additional argument housing the fired event information
+Add support for onZoomChange reporting to Uncontrolled components and include additional argument housing the fired event

--- a/.changeset/red-dingos-know.md
+++ b/.changeset/red-dingos-know.md
@@ -1,0 +1,5 @@
+---
+"react-medium-image-zoom": minor
+---
+
+Add support for onZoomChange reporting to Uncontrolled components and include additional argument housing the fired event information

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ export interface UncontrolledProps {
   // Default: false
   isDisabled?: boolean
 
+  // First argument: boolean value of a new zoomed state (Uncontrolled
+  // component) or a suggested new state (Controlled component).
+  // Second argument: object containing the event that triggered the change.
+  // Default: undefined
+  onZoomChange?: (value: boolean, data: { event: React.SyntheticEvent | Event }) => void
+
   // Swipe gesture threshold after which to unzoom.
   // Default: 10
   swipeToUnzoomThreshold?: number
@@ -137,10 +143,6 @@ export interface ControlledProps {
   // Tell the component whether or not it should be zoomed
   // Default: false
   isZoomed: boolean
-
-  // Listen for hints from the component about when you
-  // should zoom (`true` value) or unzoom (`false` value)
-  onZoomChange?: (value: boolean) => void
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ export interface UncontrolledProps {
   // component) or a suggested new state (Controlled component).
   // Second argument: object containing the event that triggered the change.
   // Default: undefined
-  onZoomChange?: (value: boolean, data: { event: React.SyntheticEvent | Event }) => void
+  onZoomChange?: (
+    value: boolean,
+    data: { event: React.SyntheticEvent | Event }
+  ) => void
 
   // Swipe gesture threshold after which to unzoom.
   // Default: 10

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -63,7 +63,7 @@ export interface ControlledProps {
   IconZoom?: React.ElementType
   isDisabled?: boolean
   isZoomed: boolean
-  onZoomChange?: (value: boolean) => void
+  onZoomChange?: (value: boolean, data: { event: React.SyntheticEvent | Event }) => void
   swipeToUnzoomThreshold?: number
   wrapElement?: 'div' | 'span'
   ZoomContent?: (data: {
@@ -71,7 +71,7 @@ export interface ControlledProps {
     img: React.ReactElement | null
     isZoomImgLoaded: boolean
     modalState: ModalState
-    onUnzoom: () => void
+    onUnzoom: (e: Event) => void
   }) => React.ReactElement
   zoomImg?: React.ImgHTMLAttributes<HTMLImageElement>
   zoomMargin?: number
@@ -527,21 +527,19 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
   /**
    * Report that zooming should occur
    */
-  handleZoom = (e: React.MouseEvent<HTMLButtonElement> | Event) => {
+  handleZoom = (e: React.SyntheticEvent | Event) => {
     if (!this.props.isDisabled && this.hasImage()) {
-      e.preventDefault()
       e.stopPropagation()
-
-      this.props.onZoomChange?.(true)
+      this.props.onZoomChange?.(true, { event: e })
     }
   }
 
   /**
    * Report that unzooming should occur
    */
-  handleUnzoom = () => {
+  handleUnzoom = (e: React.SyntheticEvent | Event) => {
     if (!this.props.isDisabled) {
-      this.props.onZoomChange?.(false)
+      this.props.onZoomChange?.(false, { event: e })
     }
   }
 
@@ -553,7 +551,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
   handleBtnUnzoomClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
     e.stopPropagation()
-    this.handleUnzoom()
+    this.handleUnzoom(e)
   }
 
   // ===========================================================================
@@ -573,7 +571,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
   handleDialogClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     if (e.target === this.refModalContent.current || e.target === this.refModalImg.current) {
       e.stopPropagation()
-      this.handleUnzoom()
+      this.handleUnzoom(e)
     }
   }
 
@@ -584,7 +582,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
    */
   handleDialogClose = (e: React.SyntheticEvent<HTMLDialogElement>) => {
     e.stopPropagation()
-    this.handleUnzoom()
+    this.handleUnzoom(e)
   }
 
   // ===========================================================================
@@ -596,7 +594,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
     if (e.key === 'Escape' || e.keyCode === 27) {
       e.preventDefault()
       e.stopPropagation()
-      this.handleUnzoom()
+      this.handleUnzoom(e)
     }
   }
 
@@ -611,7 +609,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
 
     e.stopPropagation()
     queueMicrotask(() => {
-      this.handleUnzoom()
+      this.handleUnzoom(e)
     })
   }
 
@@ -653,7 +651,7 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
       if (delta > this.props.swipeToUnzoomThreshold) {
         this.touchYStart = undefined
         this.touchYEnd = undefined
-        this.handleUnzoom()
+        this.handleUnzoom(e)
       }
     }
   }

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -529,7 +529,6 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
    */
   handleZoom = (e: React.SyntheticEvent | Event) => {
     if (!this.props.isDisabled && this.hasImage()) {
-      e.stopPropagation()
       this.props.onZoomChange?.(true, { event: e })
     }
   }

--- a/source/Controlled.tsx
+++ b/source/Controlled.tsx
@@ -527,8 +527,11 @@ class ControlledBase extends React.Component<ControlledPropsWithDefaults, Contro
   /**
    * Report that zooming should occur
    */
-  handleZoom = () => {
+  handleZoom = (e: React.MouseEvent<HTMLButtonElement> | Event) => {
     if (!this.props.isDisabled && this.hasImage()) {
+      e.preventDefault()
+      e.stopPropagation()
+
       this.props.onZoomChange?.(true)
     }
   }

--- a/source/Uncontrolled.tsx
+++ b/source/Uncontrolled.tsx
@@ -4,10 +4,18 @@ import { Controlled, ControlledProps } from './Controlled'
 // =============================================================================
 
 export type UncontrolledProps =
-  Omit<ControlledProps, 'isZoomed' | 'onZoomChange'>
+  Omit<ControlledProps, 'isZoomed'>
 
-export function Uncontrolled (props: UncontrolledProps) {
+export function Uncontrolled ({ onZoomChange, ...props }: UncontrolledProps) {
   const [isZoomed, setIsZoomed] = React.useState(false)
 
-  return <Controlled {...props} isZoomed={isZoomed} onZoomChange={setIsZoomed} />
+  const handleZoomChange = React.useCallback((
+    value: boolean,
+    { event }: { event: React.SyntheticEvent | Event }
+  ) => {
+    setIsZoomed(value)
+    onZoomChange?.(value, { event })
+  }, [onZoomChange])
+
+  return <Controlled {...props} isZoomed={isZoomed} onZoomChange={handleZoomChange} />
 }

--- a/source/Uncontrolled.tsx
+++ b/source/Uncontrolled.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Controlled, ControlledProps } from './Controlled'
+import { Controlled, type ControlledProps } from './Controlled'
 
 // =============================================================================
 
@@ -9,10 +9,9 @@ export type UncontrolledProps =
 export function Uncontrolled ({ onZoomChange, ...props }: UncontrolledProps) {
   const [isZoomed, setIsZoomed] = React.useState(false)
 
-  const handleZoomChange = React.useCallback((
-    value: boolean,
-    { event }: { event: React.SyntheticEvent | Event }
-  ) => {
+  const handleZoomChange = React.useCallback<
+    NonNullable<ControlledProps['onZoomChange']>
+  >((value, { event }) => {
     setIsZoomed(value)
     onZoomChange?.(value, { event })
   }, [onZoomChange])

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -735,6 +735,65 @@ export const SwipeToUnzoomThreshold = (props: typeof Zoom) => (
 )
 
 // =============================================================================
+
+export const SelectCards = (props: typeof Zoom) => {
+  return (
+    <main aria-label="Story">
+      <h1>Selecting cards and zooming without triggering selection state</h1>
+      <div className="mw-600" style={{ display: 'flex', flexDirection: 'column' }}>
+        <ul className="cards">
+          <CardItem
+            alt={imgThatWanakaTree.alt}
+            src={imgThatWanakaTree.src}
+            zoomProps={props}
+          />
+          <CardItem
+            alt={imgGlenorchyLagoon.alt}
+            src={imgGlenorchyLagoon.src}
+            zoomProps={props}
+          />
+        </ul>
+      </div>
+    </main>
+  )
+}
+
+function CardItem({
+  alt,
+  src,
+  zoomProps,
+}: {
+  alt: string,
+  src: string,
+  zoomProps: typeof Zoom,
+}) {
+  const [isSelected, setIsSelected] = React.useState(false)
+
+  const handleItemClick = React.useCallback(() => {
+    setIsSelected(isSelected => !isSelected)
+  }, [])
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
+    <li className="card" onClick={handleItemClick}>
+      <label>
+        <input aria-label="Select item" checked={isSelected} type="checkbox" />
+      </label>
+      <Zoom {...zoomProps} wrapElement="span">
+        <img
+          alt={alt}
+          src={src}
+          height="320"
+          width="320"
+          decoding="async"
+          loading="lazy"
+        />
+      </Zoom>
+    </li>
+  )
+}
+
+// =============================================================================
 // INTERACTIONS
 
 export const AutomatedTest = Regular.bind({}, { title: '(Automated Test)' })

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta } from '@storybook/react-webpack5'
 
 import { waitFor, within, userEvent, expect } from 'storybook/test'
 
-import Zoom, { UncontrolledProps } from '../source'
+import Zoom, { type UncontrolledProps } from '../source'
 import '../source/styles.css'
 import './base.css'
 

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -773,11 +773,25 @@ function CardItem({
     setIsSelected(isSelected => !isSelected)
   }, [])
 
+  const handleInputClick: React.MouseEventHandler<HTMLInputElement> = React.useCallback((e) => {
+    e.stopPropagation()
+  }, [])
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = React.useCallback((e) => {
+    setIsSelected(e.currentTarget.checked)
+  }, [])
+
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
     <li className="card" onClick={handleItemClick}>
       <label>
-        <input aria-label="Select item" checked={isSelected} type="checkbox" />
+        <input
+          aria-label="Select item"
+          checked={isSelected}
+          onChange={handleInputChange}
+          onClick={handleInputClick}
+          type="checkbox"
+        />
       </label>
       <Zoom {...zoomProps} wrapElement="span">
         <img

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -787,6 +787,17 @@ function CardItem({
     setIsSelected(e.currentTarget.checked)
   }, [])
 
+  const handleZoomChange = React.useCallback<
+    NonNullable<React.ComponentProps<typeof Zoom>['onZoomChange']>
+  >((value, { event }) => {
+    event.stopPropagation()
+
+    console.log(
+      'handleZoomChange (after event.stopPropagation())',
+      { value, event }
+    )
+  }, [])
+
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
     <li className="card" onClick={handleItemClick}>
@@ -799,7 +810,7 @@ function CardItem({
           type="checkbox"
         />
       </label>
-      <Zoom {...zoomProps} wrapElement="span">
+      <Zoom {...zoomProps} onZoomChange={handleZoomChange} wrapElement="span">
         <img
           alt={alt}
           src={src}

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -45,11 +45,17 @@ function shuffle<T extends unknown[]>(xs: T): T {
 // =============================================================================
 
 export const Regular = (props: typeof Zoom) => {
+  const handleZoomChange = React.useCallback<
+    NonNullable<React.ComponentProps<typeof Zoom>['onZoomChange']>
+  >((value, { event }) => {
+    console.log('handleZoomChange info!', { value, event })
+  }, [])
+
   return (
     <main aria-label="Story">
       <h1>Zooming a regular image</h1>
       <div className="mw-600" style={{ display: 'flex', flexDirection: 'column' }}>
-        <Zoom {...props} wrapElement="span">
+        <Zoom {...props} onZoomChange={handleZoomChange} wrapElement="span">
           <img
             alt={imgThatWanakaTree.alt}
             src={imgThatWanakaTree.src}

--- a/stories/base.css
+++ b/stories/base.css
@@ -143,6 +143,38 @@ img {
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
+.cards {
+  align-items: baseline;
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 2rem;
+}
+.card {
+  border: 1px solid #c0c0c0;
+  border-radius: 8px;
+  flex-shrink: 0;
+  padding-block: 3.2rem 1.2rem;
+  padding-inline: 1.2rem;
+  position: relative;
+}
+.card label {
+  align-items: center;
+  background-color: #fff;
+  display: flex;
+  height: max-content;
+  inset-block-start: 0.8rem;
+  inset-inline: auto 1rem;
+  justify-content: center;
+  position: absolute;
+  width: max-content;
+}
+.card img {
+  object-fit: cover;
+  object-position: center;
+  user-select: none;
+}
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }


### PR DESCRIPTION
## Description

Closes https://github.com/rpearce/react-medium-image-zoom/issues/939

There is no valid usage of this library inside an `<a>` or `<button>`, for that generates not only invalid HTML but incorrect accessibility. However, there is a use-case where the parent has a click event for tap/mouse users, and the accessibility is controlled elsewhere (checkbox).

<img width="1123" height="532" alt="image" src="https://github.com/user-attachments/assets/a58e2852-888a-4e8e-a3d3-96b6ac88196c" />

## Testing

1. Run the project locally on this branch: `pnpm start`
2. Navigate to http://localhost:6006/?path=/story/img--select-cards
3. Clicking the zoom/unzoom should have no effect on the selected state. Clicking the whitespace around the cards, or the checkboxes, should toggle the checkboxes.