### PR TITLE
fix: preserve original transforms and add tests

### DIFF
--- a/.changeset/soft-dryers-stay.md
+++ b/.changeset/soft-dryers-stay.md
@@ -1,0 +1,5 @@
+---
+'react-medium-image-zoom': patch
+---
+
+Fix "Mirror effect on zoomed image - transform: scaleX(-100%) doesn't work" (#363)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,7 +34,11 @@ export default [
         ...eslintConfigLove.languageOptions?.parserOptions,
         projectService: {
           ...eslintConfigLove.languageOptions?.parserOptions?.projectService,
-          allowDefaultProject: ['.storybook/main.ts', '.storybook/preview.tsx'],
+          allowDefaultProject: [
+            '.storybook/main.ts',
+            '.storybook/preview.tsx',
+            'vitest.config.ts',
+          ],
         },
       },
     },
@@ -44,6 +48,12 @@ export default [
     rules: {
       'max-lines': 'off',
       'no-console': 'off',
+    },
+  },
+  {
+    files: ['**/*.test.ts'],
+    rules: {
+      'max-lines': 'off',
     },
   },
   eslintConfigPrettier,

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "check:js": "eslint .",
     "check:js:fix": "eslint . --fix",
     "check:types": "tsc --noEmit --emitDeclarationOnly false",
-    "ci": "conc 'pnpm:check:all' 'pnpm:build' 'pnpm:build:docs'",
+    "test": "vitest run",
+    "ci": "conc 'pnpm:check:all' 'pnpm:test' 'pnpm:build' 'pnpm:build:docs'",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
     "prebuild": "rm -rf ./dist",
@@ -110,11 +111,14 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-storybook": "^10.3.4",
+    "happy-dom": "^20.8.9",
     "prettier": "^3.7.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "storybook": "^10.3.4",
-    "typescript": "^6.0.2"
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,19 +10,19 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.30.0
-        version: 2.30.0(@types/node@25.5.0)
+        version: 2.30.0(@types/node@25.6.0)
       '@storybook/addon-a11y':
         specifier: ^10.3.4
         version: 10.3.4(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-docs':
         specifier: ^10.3.4
-        version: 10.3.4(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
+        version: 10.3.4(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
       '@storybook/react-vite':
         specifier: ^10.3.4
-        version: 10.3.4(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
+        version: 10.3.4(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
       '@storybook/test-runner':
         specifier: ^0.24.3
-        version: 0.24.3(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 0.24.3(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -56,6 +56,9 @@ importers:
       eslint-plugin-storybook:
         specifier: ^10.3.4
         version: 10.3.4(eslint@9.39.4)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.8.9
       prettier:
         specifier: ^3.7.4
         version: 3.8.1
@@ -68,9 +71,15 @@ importers:
       storybook:
         specifier: ^10.3.4
         version: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))
 
 packages:
 
@@ -913,6 +922,9 @@ packages:
   '@sinonjs/fake-timers@15.1.1':
     resolution: {integrity: sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@storybook/addon-a11y@10.3.4':
     resolution: {integrity: sha512-TylBS2+MUPRfgzBKiygL1JoUBnTqEKo5oCEfjHneJZKzYE1UNgdMdk/fiyanaGKTZBKBxWbShxZhT2gLs8kqMA==}
     peerDependencies:
@@ -1159,8 +1171,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.5.0':
-    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1178,6 +1190,12 @@ packages:
 
   '@types/wait-on@5.3.4':
     resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1390,14 +1408,43 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -1775,6 +1822,10 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2074,6 +2125,10 @@ packages:
   entities@2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -2301,6 +2356,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2328,6 +2386,10 @@ packages:
   expect-playwright@0.8.0:
     resolution: {integrity: sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==}
     deprecated: ⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@30.3.0:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
@@ -2565,6 +2627,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3323,6 +3389,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3433,6 +3502,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -3747,6 +3819,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3795,6 +3870,12 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3946,12 +4027,23 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -4004,6 +4096,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -4055,8 +4152,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -4140,6 +4237,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wait-on@7.2.0:
     resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
     engines: {node: '>=12.0.0'}
@@ -4177,6 +4315,10 @@ packages:
       webpack-cli:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -4206,6 +4348,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4593,7 +4740,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.30.0(@types/node@25.5.0)':
+  '@changesets/cli@2.30.0(@types/node@25.6.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -4609,7 +4756,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.6.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -4870,12 +5017,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4899,7 +5046,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -4913,14 +5060,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest-config: 30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -4950,7 +5097,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -4968,7 +5115,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.1.1
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -4986,7 +5133,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -4997,7 +5144,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -5073,15 +5220,15 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
-      vite: 7.3.1(@types/node@25.5.0)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)
     optionalDependencies:
       typescript: 6.0.2
 
@@ -5259,16 +5406,18 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@storybook/addon-a11y@10.3.4(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.11.2
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-docs@10.3.4(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
+  '@storybook/addon-docs@10.3.4(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -5282,25 +5431,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
+  '@storybook/builder-vite@10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 7.3.1(@types/node@25.5.0)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
+  '@storybook/csf-plugin@10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
     dependencies:
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.1
-      vite: 7.3.1(@types/node@25.5.0)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)
       webpack: 5.104.1(@swc/core@1.15.21)(esbuild@0.27.7)
 
   '@storybook/global@5.0.0': {}
@@ -5316,11 +5465,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.4(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
+  '@storybook/react-vite@10.3.4(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(terser@5.46.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
+      '@storybook/builder-vite': 10.3.4(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.21)(esbuild@0.27.7))
       '@storybook/react': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -5330,7 +5479,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 7.3.1(@types/node@25.5.0)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -5352,7 +5501,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.3(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/test-runner@0.24.3(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -5362,14 +5511,14 @@ snapshots:
       '@swc/core': 1.15.21
       '@swc/jest': 0.2.39(@swc/core@1.15.21)
       expect-playwright: 0.8.0
-      jest: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest: 30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-circus: 30.3.0
       jest-environment-node: 30.3.0
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.3.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7)))
+      jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7)))
       nyc: 15.1.0
       playwright: 1.58.2
       playwright-core: 1.58.2
@@ -5546,9 +5695,9 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.5.0':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -5564,7 +5713,13 @@ snapshots:
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -5783,19 +5938,60 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -6287,6 +6483,8 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chai@6.2.2: {}
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -6542,6 +6740,8 @@ snapshots:
 
   entities@2.2.0: {}
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.4:
@@ -6682,8 +6882,7 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
-  es-module-lexer@2.0.0:
-    optional: true
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6992,6 +7191,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   events@3.3.0:
@@ -7018,6 +7221,8 @@ snapshots:
       os-homedir: 1.0.2
 
   expect-playwright@0.8.0: {}
+
+  expect-type@1.3.0: {}
 
   expect@30.3.0:
     dependencies:
@@ -7282,6 +7487,18 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.8.9:
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-bigints@1.1.0: {}
 
@@ -7621,7 +7838,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -7641,7 +7858,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
+  jest-cli@30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
     dependencies:
       '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))
       '@jest/test-result': 30.3.0
@@ -7649,7 +7866,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest-config: 30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -7660,7 +7877,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
+  jest-config@30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -7686,7 +7903,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       esbuild-register: 3.6.0(esbuild@0.27.7)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -7716,7 +7933,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -7724,7 +7941,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7770,7 +7987,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -7820,7 +8037,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -7849,7 +8066,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -7900,7 +8117,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -7915,11 +8132,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.3.0
 
-  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))):
+  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))):
     dependencies:
       ansi-escapes: 7.3.0
       chalk: 5.6.2
-      jest: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest: 30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))
       jest-regex-util: 30.0.1
       jest-watcher: 30.3.0
       slash: 5.1.0
@@ -7930,7 +8147,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -7939,25 +8156,25 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     optional: true
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
+  jest@30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7)):
     dependencies:
       '@jest/core': 30.3.0(esbuild-register@3.6.0(esbuild@0.27.7))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)(esbuild-register@3.6.0(esbuild@0.27.7))
+      jest-cli: 30.3.0(@types/node@25.6.0)(esbuild-register@3.6.0(esbuild@0.27.7))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -8257,6 +8474,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -8366,6 +8585,8 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -8719,6 +8940,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -8772,6 +8995,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8954,12 +9181,18 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -9004,6 +9237,13 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -9072,7 +9312,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
   universalify@0.1.2: {}
 
@@ -9144,7 +9384,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@7.3.1(@types/node@25.5.0)(terser@5.46.0):
+  vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9153,9 +9393,38 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       terser: 5.46.0
+      tsx: 4.21.0
+
+  vitest@4.1.4(@types/node@25.6.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.6.0)(terser@5.46.0)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      happy-dom: 20.8.9
+    transitivePeerDependencies:
+      - msw
 
   wait-on@7.2.0:
     dependencies:
@@ -9225,6 +9494,8 @@ snapshots:
       - uglify-js
     optional: true
 
+  whatwg-mimetype@3.0.0: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -9280,6 +9551,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/source/utils.test.ts
+++ b/source/utils.test.ts
@@ -1,0 +1,756 @@
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { getStyleModalImg } from './utils.js'
+
+describe('getStyleModalImg', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    })
+
+    Object.defineProperty(window, 'innerHeight', {
+      value: 0,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  describe('regular path (no loadedImgEl)', () => {
+    it('returns base position and transform when not zoomed', () => {
+      setupBrowserGlobals({ width: 1024, height: 768 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.top).toBe(100)
+      expect(result.left).toBe(50)
+      expect(result.width).toBe(400)
+      expect(result.height).toBe(300)
+      expect(result.transform).toBe('translate(0,0) scale(1)')
+    })
+
+    it('centers the image when zoomed', () => {
+      setupBrowserGlobals({ width: 1024, height: 768 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: true,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transform).toBe('translate(262px,134px) scale(1)')
+    })
+  })
+
+  describe('scalable src', () => {
+    it('scales SVG to fill viewport', () => {
+      setupBrowserGlobals({ width: 400, height: 300 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'image.svg',
+        isSvg: true,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 10,
+          left: 20,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      expect(result.width).toBe(400)
+      expect(result.height).toBe(300)
+      expect(result.transform).toBe('translate(0,0) scale(0.5)')
+    })
+
+    it('respects offset when scaling SVG', () => {
+      setupBrowserGlobals({ width: 400, height: 300 })
+
+      const withoutOffset = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'image.svg',
+        isSvg: true,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 10,
+          left: 20,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      const withOffset = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'image.svg',
+        isSvg: true,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 50,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 10,
+          left: 20,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      expect(Number(withOffset.width)).toBeLessThan(Number(withoutOffset.width))
+    })
+
+    it('treats hasZoomImg as scalable src', () => {
+      setupBrowserGlobals({ width: 400, height: 300 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: true,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 10,
+          left: 20,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      // Same as SVG: getScaleToWindow = min(400/200, 300/150) = 2
+      expect(result.width).toBe(400)
+      expect(result.height).toBe(300)
+      expect(result.transform).toBe('translate(0,0) scale(0.5)')
+    })
+  })
+
+  describe('image larger than viewport', () => {
+    it('scales down when image exceeds viewport', () => {
+      setupBrowserGlobals({ width: 400, height: 300 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 0,
+          left: 0,
+          width: 800,
+          height: 600,
+        }),
+      })
+
+      expect(result.width).toBe(400)
+      expect(result.height).toBe(300)
+      expect(result.transform).toBe('translate(0,0) scale(2)')
+    })
+
+    it('centers correctly when zoomed with scale < 1', () => {
+      setupBrowserGlobals({ width: 400, height: 300 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: true,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 0,
+          left: 0,
+          width: 800,
+          height: 600,
+        }),
+      })
+
+      expect(result.transform).toBe('translate(0px,0px) scale(1)')
+    })
+  })
+
+  describe('object-fit path', () => {
+    it('computes contain layout with natural dims larger than container', () => {
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'contain', objectPosition: '50% 50%' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 800,
+          naturalHeight: 400,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 200,
+        }),
+      })
+
+      expect(result.top).toBe(100)
+      expect(result.left).toBe(50)
+      expect(result.width).toBe(800)
+      expect(result.height).toBe(400)
+      expect(result.transform).toBe('translate(0,0) scale(0.5)')
+    })
+
+    it('computes cover layout', () => {
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'cover', objectPosition: '50% 50%' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 800,
+          naturalHeight: 400,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 400,
+        }),
+      })
+
+      expect(result.top).toBe(100)
+      expect(result.left).toBe(-150)
+      expect(result.width).toBe(800)
+      expect(result.height).toBe(400)
+      expect(result.transform).toBe('translate(0,0) scale(1)')
+    })
+  })
+
+  describe('object-fit: none', () => {
+    it('positions image at natural size without scaling to fit', () => {
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'none', objectPosition: '50% 50%' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 800,
+          naturalHeight: 400,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 200,
+        }),
+      })
+
+      // none: no ratio scaling, position based on overflow
+      // posX = 50% of (400 - 800) = -200
+      // posY = 50% of (200 - 400) = -100
+      expect(result.top).toBe(0)
+      expect(result.left).toBe(-150)
+    })
+  })
+
+  describe('object-fit: scale-down', () => {
+    it('behaves like contain when natural dims exceed container', () => {
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'scale-down', objectPosition: '50% 50%' },
+      )
+
+      const containResult = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 800,
+          naturalHeight: 400,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 200,
+        }),
+      })
+
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'contain', objectPosition: '50% 50%' },
+      )
+
+      const scaleDownResult = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 800,
+          naturalHeight: 400,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 200,
+        }),
+      })
+
+      expect(scaleDownResult).toStrictEqual(containResult)
+    })
+
+    it('behaves like none when natural dims fit within container', () => {
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'scale-down', objectPosition: '50% 50%' },
+      )
+
+      const scaleDownResult = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 200,
+          naturalHeight: 100,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 200,
+        }),
+      })
+
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { objectFit: 'none', objectPosition: '50% 50%' },
+      )
+
+      const noneResult = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 200,
+          naturalHeight: 100,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 200,
+        }),
+      })
+
+      expect(scaleDownResult).toStrictEqual(noneResult)
+    })
+  })
+
+  describe('div background path', () => {
+    it('computes cover layout for background image', () => {
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { backgroundSize: 'cover', backgroundPosition: '50% 50%' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 400,
+          naturalHeight: 300,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('div', {
+          top: 100,
+          left: 50,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      expect(result.top).toBe(100)
+      expect(result.left).toBe(50)
+      expect(result.width).toBe(400)
+      expect(result.height).toBe(300)
+      expect(result.transform).toBe('translate(0,0) scale(0.5)')
+    })
+
+    it('computes contain layout for background image', () => {
+      // viewport 800x600, container 200x200, natural 400x200
+      // contain: ratio = min(200/400, 200/200) = min(0.5, 1) = 0.5
+      // Image is narrower than cover would produce
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { backgroundSize: 'contain', backgroundPosition: '50% 50%' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 400,
+          naturalHeight: 200,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('div', {
+          top: 100,
+          left: 50,
+          width: 200,
+          height: 200,
+        }),
+      })
+
+      // contain uses Math.min, so width constrains
+      // ratio = 0.5, scaled natural: 200x100
+      // posY = 50% of (200 - 200*0.5) = 50
+      expect(result.top).toBe(150)
+      expect(result.left).toBe(50)
+    })
+
+    it('computes auto layout for background image', () => {
+      // backgroundSize=auto uses natural dims directly (no ratio scaling)
+      setupBrowserGlobals(
+        { width: 800, height: 600 },
+        { backgroundSize: 'auto', backgroundPosition: '50% 50%' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 400,
+          naturalHeight: 300,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('div', {
+          top: 100,
+          left: 50,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      // auto: posX = 50% of (200 - 400) = -100, posY = 50% of (150 - 300) = -75
+      expect(result.top).toBe(25)
+      expect(result.left).toBe(-50)
+    })
+  })
+
+  describe('natural dimensions from loadedImgEl', () => {
+    it('uses natural dimensions when loadedImgEl is provided', () => {
+      setupBrowserGlobals({ width: 800, height: 600 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: createLoadedImgEl({
+          naturalWidth: 400,
+          naturalHeight: 300,
+        }),
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 200,
+          height: 150,
+        }),
+      })
+
+      expect(result.width).toBe(400)
+      expect(result.height).toBe(300)
+    })
+  })
+
+  describe('user CSS transform preservation', () => {
+    it('appends centered user transform when not zoomed', () => {
+      setupBrowserGlobals(
+        { width: 1024, height: 768 },
+        { transform: 'matrix(-1, 0, 0, 1, 0, 0)' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transform).toBe(
+        'translate(0,0) scale(1) translate(200px,150px) matrix(-1, 0, 0, 1, 0, 0) translate(-200px,-150px)',
+      )
+    })
+
+    it('includes centered user transform when zoomed', () => {
+      setupBrowserGlobals(
+        { width: 1024, height: 768 },
+        { transform: 'matrix(-1, 0, 0, 1, 0, 0)' },
+      )
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: true,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transform).toBe(
+        'translate(262px,134px) scale(1) translate(200px,150px) matrix(-1, 0, 0, 1, 0, 0) translate(-200px,-150px)',
+      )
+    })
+
+    it('is a no-op when computed transform is "none"', () => {
+      setupBrowserGlobals({ width: 1024, height: 768 }, { transform: 'none' })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transform).toBe('translate(0,0) scale(1)')
+    })
+
+    it('is a no-op when computed transform is empty', () => {
+      setupBrowserGlobals({ width: 1024, height: 768 }, { transform: '' })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: false,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transform).toBe('translate(0,0) scale(1)')
+    })
+  })
+
+  describe('shouldRefresh', () => {
+    it('sets transitionDuration when zoomed and shouldRefresh', () => {
+      setupBrowserGlobals({ width: 1024, height: 768 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: true,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: true,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transitionDuration).toBe('0.01ms')
+    })
+
+    it('does not set transitionDuration when not zoomed', () => {
+      setupBrowserGlobals({ width: 1024, height: 768 })
+
+      const result = getStyleModalImg({
+        hasZoomImg: false,
+        imgSrc: 'photo.jpg',
+        isSvg: false,
+        isZoomed: false,
+        loadedImgEl: undefined,
+        offset: 0,
+        shouldRefresh: true,
+        targetEl: createTargetEl('img', {
+          top: 100,
+          left: 50,
+          width: 400,
+          height: 300,
+        }),
+      })
+
+      expect(result.transitionDuration).toBeUndefined()
+    })
+  })
+})
+
+interface MockComputedStyle {
+  objectFit: string
+  objectPosition: string
+  backgroundPosition: string
+  backgroundSize: string
+  transform: string
+}
+
+function setupBrowserGlobals(
+  viewport: { width: number; height: number },
+  computedStyle?: Partial<MockComputedStyle>,
+): void {
+  const cs: MockComputedStyle = {
+    objectFit: 'fill',
+    objectPosition: '50% 50%',
+    backgroundPosition: '50% 50%',
+    backgroundSize: 'auto',
+    transform: 'none',
+    ...computedStyle,
+  }
+
+  Object.defineProperty(window, 'innerWidth', {
+    value: viewport.width,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    value: viewport.height,
+    configurable: true,
+    writable: true,
+  })
+
+  const baseStyle = window.getComputedStyle(document.createElement('div'))
+
+  for (const [key, value] of Object.entries(cs)) {
+    Object.defineProperty(baseStyle, key, { value, configurable: true })
+  }
+
+  vi.spyOn(window, 'getComputedStyle').mockReturnValue(baseStyle)
+}
+
+function createTargetEl<K extends 'div' | 'img' | 'span'>(
+  tagName: K,
+  rect: { top: number; left: number; width: number; height: number },
+): HTMLElementTagNameMap[K] {
+  const el = document.createElement(tagName)
+
+  el.getBoundingClientRect = (): DOMRect => ({
+    ...rect,
+    right: rect.left + rect.width,
+    bottom: rect.top + rect.height,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => undefined,
+  })
+
+  return el
+}
+
+function createLoadedImgEl(dims: {
+  naturalWidth: number
+  naturalHeight: number
+}): HTMLImageElement {
+  const el = document.createElement('img')
+
+  Object.defineProperty(el, 'naturalWidth', { value: dims.naturalWidth })
+  Object.defineProperty(el, 'naturalHeight', { value: dims.naturalHeight })
+
+  return el
+}

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -519,6 +519,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
     loadedImgEl != null && loadedImgEl.naturalHeight !== 0
       ? loadedImgEl.naturalHeight
       : imgRect.height
+
   const targetWidth =
     loadedImgEl != null && loadedImgEl.naturalWidth !== 0
       ? loadedImgEl.naturalWidth
@@ -571,6 +572,27 @@ export const getStyleModalImg: GetStyleModalImg = ({
     ...styleDivImg,
   }
 
+  // Preserve any CSS transform (e.g. scaleX(-1)) on the source element so
+  // the modal image matches it. The translates recenter around the element's
+  // midpoint to compensate for transform-origin: top-left (set in styles.css).
+  const { transform: userTransform } = targetElComputedStyle
+  let centeredUserTransform = ''
+
+  if (userTransform !== 'none' && userTransform !== '') {
+    const halfWidth = parseFloat(String(style.width ?? 0)) / 2
+    const halfHeight = parseFloat(String(style.height ?? 0)) / 2
+
+    centeredUserTransform = [
+      `translate(${halfWidth}px,${halfHeight}px)`,
+      userTransform,
+      `translate(${-halfWidth}px,${-halfHeight}px)`,
+    ].join(' ')
+  }
+
+  style.transform = [String(style.transform), centeredUserTransform]
+    .filter(Boolean)
+    .join(' ')
+
   if (isZoomed) {
     const viewportX = window.innerWidth / 2
     const viewportY = window.innerHeight / 2
@@ -578,6 +600,7 @@ export const getStyleModalImg: GetStyleModalImg = ({
     const childCenterX =
       parseFloat(String(style.left ?? 0)) +
       parseFloat(String(style.width ?? 0)) / 2
+
     const childCenterY =
       parseFloat(String(style.top ?? 0)) +
       parseFloat(String(style.height ?? 0)) / 2
@@ -590,7 +613,13 @@ export const getStyleModalImg: GetStyleModalImg = ({
       style.transitionDuration = '0.01ms'
     }
 
-    style.transform = `translate(${translateX}px,${translateY}px) scale(1)`
+    style.transform = [
+      `translate(${translateX}px,${translateY}px)`,
+      'scale(1)',
+      centeredUserTransform,
+    ]
+      .filter(Boolean)
+      .join(' ')
   }
 
   return style

--- a/stories/CSSTransform.stories.tsx
+++ b/stories/CSSTransform.stories.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import type { Meta, StoryFn } from '@storybook/react-vite'
+
+import Zoom from '../source'
+import '../source/styles.css'
+import './base.css'
+
+import { imgThatWanakaTree, imgTeAraiPoint } from './images'
+
+const meta: Meta<typeof Zoom> = {
+  title: 'CSS Transform',
+  component: Zoom,
+}
+
+export default meta
+
+type Story = StoryFn<typeof Zoom>
+
+// =============================================================================
+
+export const MirrorHorizontal: Story = props => (
+  <main aria-label="Story">
+    <h1>
+      Mirrored image with <code>transform: scaleX(-1)</code>
+    </h1>
+    <div className="mw-600">
+      <p>
+        The zoomed image should appear mirrored horizontally, matching the
+        original.
+      </p>
+      <Zoom {...props}>
+        <img
+          alt={imgThatWanakaTree.alt}
+          src={imgThatWanakaTree.src}
+          height="320"
+          style={{ transform: 'scaleX(-1)' }}
+          decoding="async"
+          loading="lazy"
+        />
+      </Zoom>
+    </div>
+  </main>
+)
+
+// =============================================================================
+
+export const MirrorVertical: Story = props => (
+  <main aria-label="Story">
+    <h1>
+      Mirrored image with <code>transform: scaleY(-1)</code>
+    </h1>
+    <div className="mw-600">
+      <p>
+        The zoomed image should appear mirrored vertically, matching the
+        original.
+      </p>
+      <Zoom {...props}>
+        <img
+          alt={imgTeAraiPoint.alt}
+          src={imgTeAraiPoint.src}
+          height="320"
+          style={{ transform: 'scaleY(-1)' }}
+          decoding="async"
+          loading="lazy"
+        />
+      </Zoom>
+    </div>
+  </main>
+)
+
+// =============================================================================
+
+export const MirrorBoth: Story = props => (
+  <main aria-label="Story">
+    <h1>
+      Mirrored image with <code>transform: scale(-1, -1)</code>
+    </h1>
+    <div className="mw-600">
+      <p>
+        The zoomed image should appear mirrored both horizontally and
+        vertically, matching the original.
+      </p>
+      <Zoom {...props}>
+        <img
+          alt={imgThatWanakaTree.alt}
+          src={imgThatWanakaTree.src}
+          height="320"
+          style={{ transform: 'scale(-1, -1)' }}
+          decoding="async"
+          loading="lazy"
+        />
+      </Zoom>
+    </div>
+  </main>
+)

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["source/**/*"],
+  "exclude": ["source/**/*.test.ts"],
   "compilerOptions": {
     "noEmit": false,
     "rootDir": "./source"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['source/**/*.test.ts'],
+    restoreMocks: true,
+  },
+})


### PR DESCRIPTION
## Description

Fixes https://github.com/rpearce/react-medium-image-zoom/issues/363 and adds automated testing for the main utility function that was altered. Used Claude—with great criticism from me—to come up with the solution and tests.

## Testing

1. Check out this branch
2. `pnpm i && pnpm start`
3. Go test the CSS Transform stories: http://localhost:6006/?path=/story/css-transform--mirror-horizontal
4. Test other stories