### PR TITLE
chore: pnpm workspace

### DIFF
--- a/.changeset/quiet-swans-act.md
+++ b/.changeset/quiet-swans-act.md
@@ -1,0 +1,5 @@
+---
+'react-medium-image-zoom': patch
+---
+
+set pnpm cooldown for (dev) dependencies and leverage pnpm-workspace.yaml

--- a/package.json
+++ b/package.json
@@ -124,10 +124,5 @@
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "esbuild"
-    ]
-  }
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+ignoredBuiltDependencies:
+  - '@swc/core'
+  - 'esbuild'
+  - 'unrs-resolver'
+
+minimumReleaseAge: 2880
+
+strictDepBuilds: true


### PR DESCRIPTION
## Description

* Sets cooldown/minimum release age for dependencies
* Explicitly ignores lifecycle install scripts from dependencies
* Will break if any of those install scripts are found and not accounted for
