### PR TITLE
fix: controlled with zoomcontent breaks

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -713,6 +713,13 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/17525378?v=4",
       "profile": "https://github.com/MichalKowalczyk",
       "contributions": ["bug"]
+    },
+    {
+      "login": "tarngerine",
+      "name": "Julius Tarng",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1629901?v=4",
+      "profile": "https://github.com/tarngerine",
+      "contributions": ["bug"]
     }
   ],
   "repoType": "github",

--- a/.changeset/dry-baboons-hug.md
+++ b/.changeset/dry-baboons-hug.md
@@ -1,0 +1,5 @@
+---
+'react-medium-image-zoom': patch
+---
+
+fix "Using Controlled zoom & ZoomContent at the same time breaks" (#448)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-medium-image-zoom
 
-[![npm version](https://img.shields.io/npm/v/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![bundlephobia size](https://badgen.net/bundlephobia/minzip/react-medium-image-zoom)](https://bundlephobia.com/result?p=react-medium-image-zoom) [![npm downloads](https://img.shields.io/npm/dm/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![All Contributors](https://img.shields.io/badge/all_contributors-96-orange.svg)](#contributors-)
+[![npm version](https://img.shields.io/npm/v/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![bundlephobia size](https://badgen.net/bundlephobia/minzip/react-medium-image-zoom)](https://bundlephobia.com/package/react-medium-image-zoom) [![npm downloads](https://img.shields.io/npm/dm/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![All Contributors](https://img.shields.io/badge/all_contributors-96-orange.svg)](#contributors-)
 
 The original [medium.com-inspired image zooming](https://medium.design/image-zoom-on-medium-24d146fc0c20)
 library for [React](https://reactjs.org).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-medium-image-zoom
 
-[![npm version](https://img.shields.io/npm/v/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![bundlephobia size](https://badgen.net/bundlephobia/minzip/react-medium-image-zoom)](https://bundlephobia.com/result?p=react-medium-image-zoom) [![npm downloads](https://img.shields.io/npm/dm/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![All Contributors](https://img.shields.io/badge/all_contributors-95-orange.svg)](#contributors-)
+[![npm version](https://img.shields.io/npm/v/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![bundlephobia size](https://badgen.net/bundlephobia/minzip/react-medium-image-zoom)](https://bundlephobia.com/result?p=react-medium-image-zoom) [![npm downloads](https://img.shields.io/npm/dm/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![All Contributors](https://img.shields.io/badge/all_contributors-96-orange.svg)](#contributors-)
 
 The original [medium.com-inspired image zooming](https://medium.design/image-zoom-on-medium-24d146fc0c20)
 library for [React](https://reactjs.org).
@@ -496,6 +496,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://mwspace.com/"><img src="https://avatars.githubusercontent.com/u/29952045?v=4?s=40" width="40px;" alt="MwSpace llc"/><br /><sub><b>MwSpace llc</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3AMwSpaceLLC" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://skk.moe/"><img src="https://avatars.githubusercontent.com/u/40715044?v=4?s=40" width="40px;" alt="Sukka"/><br /><sub><b>Sukka</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/commits?author=SukkaW" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/MichalKowalczyk"><img src="https://avatars.githubusercontent.com/u/17525378?v=4?s=40" width="40px;" alt="Michał Kowalczyk"/><br /><sub><b>Michał Kowalczyk</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3AMichalKowalczyk" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/tarngerine"><img src="https://avatars.githubusercontent.com/u/1629901?v=4?s=40" width="40px;" alt="Julius Tarng"/><br /><sub><b>Julius Tarng</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3Atarngerine" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/controlled.test.tsx
+++ b/src/controlled.test.tsx
@@ -202,6 +202,60 @@ describe('Controlled', () => {
     unmount()
     expect(document.body.style.overflow).toBe('auto')
   })
+
+  // Regression: https://github.com/rpearce/react-medium-image-zoom/issues/448
+  // When a parent passes an inline `ZoomContent={(props) => ...}` whose
+  // function identity changes on every render, the ZoomContent subtree
+  // remounts on each parent re-render, which remounts the modalImg.  The
+  // transitionend handler must survive that remount, otherwise unzoom gets
+  // stuck in UNLOADING, body scroll is never restored, and the dialog is
+  // never closed.
+  it('unzoom still completes when ZoomContent identity changes each render', async () => {
+    document.body.style.overflow = 'auto'
+    const { rerender } = await renderZoom({
+      isZoomed: false,
+      ZoomContent: props => (
+        <>
+          {props.buttonUnzoom}
+          {props.img}
+        </>
+      ),
+    })
+
+    // Zoom in.  This re-render passes a *new* inline ZoomContent function
+    // because renderZoom's rerender reconstructs the element each call.
+    await rerender({
+      isZoomed: true,
+      ZoomContent: props => (
+        <>
+          {props.buttonUnzoom}
+          {props.img}
+        </>
+      ),
+    })
+    expect(document.body.style.overflow).toBe('hidden')
+
+    const modalImgZoomed = getPortalModalImg()
+    if (modalImgZoomed !== null) await fireTransitionEnd(modalImgZoomed)
+    expect(getPortalDialog()?.open).toBe(true)
+
+    // Unzoom with *another* new inline ZoomContent.
+    await rerender({
+      isZoomed: false,
+      ZoomContent: props => (
+        <>
+          {props.buttonUnzoom}
+          {props.img}
+        </>
+      ),
+    })
+
+    const modalImgUnzoomed = getPortalModalImg()
+    if (modalImgUnzoomed !== null) await fireTransitionEnd(modalImgUnzoomed)
+
+    expect(document.body.style.overflow).toBe('auto')
+    expect(getPortalDialog()?.open).toBe(false)
+  })
 })
 
 // =============================================================================
@@ -271,7 +325,7 @@ function getPortalModalContent(): HTMLElement | null {
 
 async function fireTransitionEnd(el: Element): Promise<void> {
   await act(async () => {
-    el.dispatchEvent(new Event('transitionend'))
+    el.dispatchEvent(new Event('transitionend', { bubbles: true }))
     await Promise.resolve()
   })
 }

--- a/src/controlled.test.tsx
+++ b/src/controlled.test.tsx
@@ -251,6 +251,7 @@ describe('Controlled', () => {
     })
 
     const modalImgUnzoomed = getPortalModalImg()
+    expect(modalImgUnzoomed).not.toBe(modalImgZoomed)
     if (modalImgUnzoomed !== null) await fireTransitionEnd(modalImgUnzoomed)
 
     expect(document.body.style.overflow).toBe('auto')

--- a/src/controlled.tsx
+++ b/src/controlled.tsx
@@ -186,7 +186,6 @@ class ControlledBase extends React.Component<
         classDialog,
         IconUnzoom,
         IconZoom,
-        isZoomed,
         wrapElement: WrapElement,
         ZoomContent,
         zoomImg,
@@ -247,13 +246,20 @@ class ControlledBase extends React.Component<
     }
 
     // Share this with UNSAFE_handleSvg
+    // NOTE: drive the "zoomed" style off modalState only (not `isZoomed`).
+    // When a consumer passes an inline `ZoomContent` whose identity changes
+    // per render, the ZoomContent subtree remounts on each parent render.
+    // Using `isZoomed` prop here would cause the fresh modalImg to mount
+    // directly in the unzoomed state on the way out, skipping the transition.
+    // Driving off modalState means the new modalImg mounts zoomed at LOADED and
+    // transitions to unzoomed when we flip to UNLOADING.
     this.styleModalImg =
       hasImage && imgEl !== null
         ? getStyleModalImg({
             hasZoomImg,
             imgSrc,
             isSvg,
-            isZoomed: isZoomed && isModalActive,
+            isZoomed: isModalActive,
             loadedImgEl,
             offset: zoomMargin,
             shouldRefresh,
@@ -279,6 +285,7 @@ class ControlledBase extends React.Component<
             data-rmiz-modal-img=""
             height={this.styleModalImg.height ?? undefined}
             id={idModalImg}
+            onTransitionEnd={this.handleImgTransitionEnd}
             ref={refModalImg}
             style={this.styleModalImg}
             width={this.styleModalImg.width ?? undefined}
@@ -286,6 +293,7 @@ class ControlledBase extends React.Component<
         ) : isSvg ? (
           <div
             data-rmiz-modal-img
+            onTransitionEnd={this.handleImgTransitionEnd}
             ref={refModalImg}
             style={this.styleModalImg}
           />
@@ -385,10 +393,7 @@ class ControlledBase extends React.Component<
     this.imgElResizeObserver?.disconnect()
     this.imgEl?.removeEventListener('load', this.handleImgLoad)
     this.imgEl?.removeEventListener('click', this.handleZoom)
-    this.refModalImg.current?.removeEventListener(
-      'transitionend',
-      this.handleImgTransitionEnd,
-    )
+    clearTimeout(this.timeoutTransitionEnd)
     window.removeEventListener('wheel', this.handleWheel)
     window.removeEventListener('touchstart', this.handleTouchStart)
     window.removeEventListener('touchmove', this.handleTouchMove)
@@ -409,7 +414,6 @@ class ControlledBase extends React.Component<
     this.handleIfZoomChanged(prevProps.isZoomed)
   }
 
-  // eslint-disable-next-line complexity -- state machine handler with one branch per modal state transition
   handleModalStateChange = (
     prevModalState: ControlledState['modalState'],
   ): void => {
@@ -446,10 +450,6 @@ class ControlledBase extends React.Component<
     } else if (prevModalState !== 'UNLOADED' && modalState === 'UNLOADED') {
       this.bodyScrollEnable()
       window.removeEventListener('resize', this.handleResize)
-      this.refModalImg.current?.removeEventListener(
-        'transitionend',
-        this.handleImgTransitionEnd,
-      )
       this.refDialog.current?.close()
     }
   }
@@ -765,10 +765,6 @@ class ControlledBase extends React.Component<
   zoom = (): void => {
     this.bodyScrollDisable()
     this.refDialog.current?.showModal()
-    this.refModalImg.current?.addEventListener(
-      'transitionend',
-      this.handleImgTransitionEnd,
-    ) // must be added after showModal
     this.setState({ modalState: 'LOADING' })
   }
 

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -3,7 +3,10 @@ import type { Meta, StoryFn } from '@storybook/react-vite'
 
 import { waitFor, within, userEvent, expect } from 'storybook/test'
 
-import Zoom, { type UncontrolledProps } from '../src'
+import Zoom, {
+  Controlled as ControlledZoom,
+  type UncontrolledProps,
+} from '../src'
 import '../src/styles.css'
 import './base.css'
 
@@ -400,28 +403,65 @@ export const ZoomImageFromInsideDialog: Story = props => {
 }
 // =============================================================================
 
-export const ModalFigureCaption: Story = props => (
-  <main aria-label="Story">
-    <h1>Modal With Figure And Caption</h1>
-    <p>
-      If you want more control over the zoom modal&apos;s content, you can pass
-      a <code>ZoomContent</code> component
-    </p>
-    <div className="mw-600">
-      <Zoom {...props} ZoomContent={CustomZoomContent}>
-        <img
-          alt={imgThatWanakaTree.alt}
-          src={imgThatWanakaTree.src}
-          height="320"
-          decoding="async"
-          loading="lazy"
-        />
-      </Zoom>
-    </div>
-  </main>
-)
+export const ModalFigureCaption: Story = props => {
+  const [isZoomed, setIsZoomed] = React.useState(false)
 
-const CustomZoomContent: UncontrolledProps['ZoomContent'] = ({
+  const handleZoomChange = React.useCallback((value: boolean) => {
+    setIsZoomed(value)
+  }, [])
+
+  return (
+    <main aria-label="Story">
+      <h1>Modal With Figure And Caption</h1>
+      <p>
+        If you want more control over the zoom modal&apos;s content, you can
+        pass a <code>ZoomContent</code> component.
+      </p>
+
+      <h2>Uncontrolled</h2>
+      <div className="mw-600">
+        <Zoom {...props} ZoomContent={CustomZoomContent}>
+          <img
+            alt={imgThatWanakaTree.alt}
+            src={imgThatWanakaTree.src}
+            height="320"
+            decoding="async"
+            loading="lazy"
+          />
+        </Zoom>
+      </div>
+
+      <h2>Controlled</h2>
+      <p>
+        Regression for{' '}
+        <a href="https://github.com/rpearce/react-medium-image-zoom/issues/448">
+          issue #448
+        </a>
+        : when the parent owns <code>isZoomed</code> and passes{' '}
+        <code>ZoomContent</code> as an inline arrow function, its identity
+        changes on every parent render, causing the modal subtree to remount.
+        Zoom and unzoom should both animate smoothly.
+      </p>
+      <div className="mw-600">
+        <ControlledZoom
+          isZoomed={isZoomed}
+          onZoomChange={handleZoomChange}
+          ZoomContent={zoomProps => <CustomZoomContent {...zoomProps} />}
+        >
+          <img
+            alt={imgThatWanakaTree.alt}
+            src={imgThatWanakaTree.src}
+            height="320"
+            decoding="async"
+            loading="lazy"
+          />
+        </ControlledZoom>
+      </div>
+    </main>
+  )
+}
+
+const CustomZoomContent: NonNullable<UncontrolledProps['ZoomContent']> = ({
   buttonUnzoom,
   modalState,
   img,


### PR DESCRIPTION
## Description

Closes https://github.com/rpearce/react-medium-image-zoom/issues/448 by using a React `onTransitionEnd` instead of a manual one added in certain scenarios.

Also:

* Adds a test
* Adds a story (for `ZoomContent`, `Uncontrolled` vs `Controlled`)
* Adds the bug creator as an all contributor
* Fixes a README link (completely separate, but I'm here...)
* Clearing out a timer from a different fix (Safari one) we own that may interfere