### PR TITLE
fix: zoom close scroll jump

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -727,6 +727,13 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/13614780?v=4",
       "profile": "https://github.com/joeyvanlierop",
       "contributions": ["bug", "review"]
+    },
+    {
+      "login": "fakkio",
+      "name": "Fabio Lazzaroni",
+      "avatar_url": "https://avatars.githubusercontent.com/u/15056746?v=4",
+      "profile": "https://fabiolazzaroni.dev/",
+      "contributions": ["bug"]
     }
   ],
   "repoType": "github",

--- a/.changeset/quick-scrolls-restore.md
+++ b/.changeset/quick-scrolls-restore.md
@@ -1,0 +1,5 @@
+---
+'react-medium-image-zoom': patch
+---
+
+fix: restore scroll position instantly on unzoom so pages with `scroll-behavior: smooth` no longer animate from the top of the document back to the previous position #1085

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-medium-image-zoom
 
-[![npm version](https://img.shields.io/npm/v/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![bundlephobia size](https://badgen.net/bundlephobia/minzip/react-medium-image-zoom)](https://bundlephobia.com/package/react-medium-image-zoom) [![npm downloads](https://img.shields.io/npm/dm/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![All Contributors](https://img.shields.io/badge/all_contributors-97-orange.svg)](#contributors-)
+[![npm version](https://img.shields.io/npm/v/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![bundlephobia size](https://badgen.net/bundlephobia/minzip/react-medium-image-zoom)](https://bundlephobia.com/package/react-medium-image-zoom) [![npm downloads](https://img.shields.io/npm/dm/react-medium-image-zoom.svg)](https://www.npmjs.com/package/react-medium-image-zoom) [![All Contributors](https://img.shields.io/badge/all_contributors-98-orange.svg)](#contributors-)
 
 The original [medium.com-inspired image zooming](https://medium.design/image-zoom-on-medium-24d146fc0c20)
 library for [React](https://reactjs.org).
@@ -498,6 +498,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/MichalKowalczyk"><img src="https://avatars.githubusercontent.com/u/17525378?v=4?s=40" width="40px;" alt="Michał Kowalczyk"/><br /><sub><b>Michał Kowalczyk</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3AMichalKowalczyk" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/tarngerine"><img src="https://avatars.githubusercontent.com/u/1629901?v=4?s=40" width="40px;" alt="Julius Tarng"/><br /><sub><b>Julius Tarng</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3Atarngerine" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/joeyvanlierop"><img src="https://avatars.githubusercontent.com/u/13614780?v=4?s=40" width="40px;" alt="Joey Van Lierop"/><br /><sub><b>Joey Van Lierop</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3Ajoeyvanlierop" title="Bug reports">🐛</a> <a href="https://github.com/rpearce/react-medium-image-zoom/pulls?q=is%3Apr+reviewed-by%3Ajoeyvanlierop" title="Reviewed Pull Requests">👀</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://fabiolazzaroni.dev/"><img src="https://avatars.githubusercontent.com/u/15056746?v=4?s=40" width="40px;" alt="Fabio Lazzaroni"/><br /><sub><b>Fabio Lazzaroni</b></sub></a><br /><a href="https://github.com/rpearce/react-medium-image-zoom/issues?q=author%3Afakkio" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/controlled.test.tsx
+++ b/src/controlled.test.tsx
@@ -203,6 +203,35 @@ describe('Controlled', () => {
     expect(document.body.style.overflow).toBe('auto')
   })
 
+  // Regression: https://github.com/rpearce/react-medium-image-zoom/issues/1085
+  // The position:fixed scroll lock restores the page's scroll position on
+  // unzoom.  Restoring it with the legacy `scrollTo(x, y)` form honors a
+  // page-level `scroll-behavior: smooth` (common in Next.js), so the page
+  // animates from the top of the document down to the previous position - a
+  // visible jump.  The restore must be instant regardless of scroll-behavior.
+  it('restores scroll position instantly on unzoom, ignoring smooth scroll', async () => {
+    Object.defineProperty(window, 'scrollY', { value: 500, configurable: true })
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(noop)
+
+    try {
+      const { rerender } = await renderZoom({ isZoomed: false })
+
+      await rerender({ isZoomed: true })
+      const modalImg = getPortalModalImg()
+      if (modalImg !== null) await fireTransitionEnd(modalImg)
+
+      await rerender({ isZoomed: false })
+      if (modalImg !== null) await fireTransitionEnd(modalImg)
+
+      expect(scrollToSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 500, behavior: 'instant' }),
+      )
+    } finally {
+      scrollToSpy.mockRestore()
+      Object.defineProperty(window, 'scrollY', { value: 0, configurable: true })
+    }
+  })
+
   // Regression: https://github.com/rpearce/react-medium-image-zoom/issues/448
   // When a parent passes an inline `ZoomContent={(props) => ...}` whose
   // function identity changes on every render, the ZoomContent subtree

--- a/src/controlled.tsx
+++ b/src/controlled.tsx
@@ -857,7 +857,10 @@ class ControlledBase extends React.Component<
     bodyStyle.position = prev.position
     bodyStyle.top = prev.top
     bodyStyle.overflow = prev.overflow
-    window.scrollTo(0, this.prevScrollY)
+    // `behavior: 'instant'` so restoring the scroll position is not animated by
+    // a page-level `scroll-behavior: smooth`, which would otherwise scroll from
+    // the top of the document down to the previous position (#1085).
+    window.scrollTo({ left: 0, top: this.prevScrollY, behavior: 'instant' })
     this.prevBodyAttrs = defaultBodyAttrs
     this.prevScrollY = 0
   }

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -867,6 +867,67 @@ function CardItem({
 }
 
 // =============================================================================
+
+/**
+ * Manual regression demo for #1085: with `scroll-behavior: smooth`, closing the
+ * zoom must restore the scroll position instantly, with no animated jump.
+ * https://github.com/rpearce/react-medium-image-zoom/issues/1085
+ */
+export const ScrollRestoreOnClose: Story = props => {
+  // #1085 only reproduces with smooth scrolling enabled.
+  React.useEffect(() => {
+    const html = document.documentElement
+    const prev = html.style.scrollBehavior
+    html.style.scrollBehavior = 'smooth'
+
+    return () => {
+      html.style.scrollBehavior = prev
+    }
+  }, [])
+
+  return (
+    <main aria-label="Story">
+      <div style={{ padding: 16, maxWidth: 640 }}>
+        <h1>Scroll restore on close (#1085)</h1>
+        <p>
+          Scroll down to the image, zoom it, then close it. Your position should
+          restore <strong>instantly</strong> — no jump — even though this page
+          uses <code>scroll-behavior: smooth</code>.
+        </p>
+      </div>
+
+      <div
+        aria-hidden="true"
+        style={{
+          height: '150vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#888',
+          background: 'linear-gradient(#fafafa, #d8d8d8)',
+        }}
+      >
+        ↓ keep scrolling ↓
+      </div>
+
+      <div style={{ padding: 16, maxWidth: 640 }}>
+        <Zoom {...props}>
+          <img
+            alt={imgThatWanakaTree.alt}
+            src={imgThatWanakaTree.src}
+            height="320"
+            decoding="async"
+          />
+        </Zoom>
+      </div>
+
+      <div aria-hidden="true" style={{ height: '120vh' }} />
+    </main>
+  )
+}
+ScrollRestoreOnClose.parameters = { layout: 'fullscreen' }
+
+// =============================================================================
 // INTERACTIONS
 
 export const AutomatedTest: Story = Regular.bind({})


### PR DESCRIPTION
## Description

Closes https://github.com/rpearce/react-medium-image-zoom/issues/1085 by making sure the repositioning scroll behavior is instant, avoiding common animated scroll behavior.

## Testing

Run this branch and look at the new story, following its directions. If you do it in `main` in Safari, you'll see the bug.
