### PR TITLE
fix: jank because of wrongly using position:fixed 

### DIFF
--- a/.changeset/remove-body-scroll-lock-position-fixed.md
+++ b/.changeset/remove-body-scroll-lock-position-fixed.md
@@ -1,0 +1,5 @@
+---
+'react-medium-image-zoom': patch
+---
+
+fix: opening or closing a zoom no longer shifts the page's scroll position, so scroll-driven UI (sticky/condensing headers, scroll-spies, scroll-triggered animations) no longer fires as though the user scrolled #1085

--- a/src/controlled.test.tsx
+++ b/src/controlled.test.tsx
@@ -176,22 +176,6 @@ describe('Controlled', () => {
     expectCalledWith(onZoomChange, false)
   })
 
-  it('disables body scroll on zoom and restores it after full unload', async () => {
-    document.body.style.overflow = 'auto'
-    const { rerender } = await renderZoom({ isZoomed: false })
-
-    await rerender({ isZoomed: true })
-    expect(document.body.style.overflow).toBe('hidden')
-
-    const modalImg = getPortalModalImg()
-    if (modalImg !== null) await fireTransitionEnd(modalImg)
-
-    await rerender({ isZoomed: false })
-    if (modalImg !== null) await fireTransitionEnd(modalImg)
-
-    expect(document.body.style.overflow).toBe('auto')
-  })
-
   it('restores body scroll if unmounted while zoomed', async () => {
     document.body.style.overflow = 'auto'
     const { rerender, unmount } = await renderZoom({ isZoomed: false })
@@ -204,12 +188,12 @@ describe('Controlled', () => {
   })
 
   // Regression: https://github.com/rpearce/react-medium-image-zoom/issues/1085
-  // The position:fixed scroll lock restores the page's scroll position on
-  // unzoom.  Restoring it with the legacy `scrollTo(x, y)` form honors a
-  // page-level `scroll-behavior: smooth` (common in Next.js), so the page
-  // animates from the top of the document down to the previous position - a
-  // visible jump.  The restore must be instant regardless of scroll-behavior.
-  it('restores scroll position instantly on unzoom, ignoring smooth scroll', async () => {
+  // The lock must not use `position: fixed`/`scrollTo`: those zero
+  // `window.scrollY` and fire scroll events on lock/unlock that spuriously
+  // trigger scroll-position-driven UI on close. `overflow: hidden` alone leaves
+  // `window.scrollY` untouched.
+  it('locks with overflow only and never scrolls the window', async () => {
+    document.body.style.overflow = 'auto'
     Object.defineProperty(window, 'scrollY', { value: 500, configurable: true })
     const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(noop)
 
@@ -217,15 +201,19 @@ describe('Controlled', () => {
       const { rerender } = await renderZoom({ isZoomed: false })
 
       await rerender({ isZoomed: true })
+      expect(document.body.style.overflow).toBe('hidden')
+      expect(document.body.style.position).not.toBe('fixed')
+      expect(document.body.style.top).toBe('')
+
       const modalImg = getPortalModalImg()
       if (modalImg !== null) await fireTransitionEnd(modalImg)
 
       await rerender({ isZoomed: false })
       if (modalImg !== null) await fireTransitionEnd(modalImg)
 
-      expect(scrollToSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ top: 500, behavior: 'instant' }),
-      )
+      // Restored to the original value, and the window was never scrolled.
+      expect(document.body.style.overflow).toBe('auto')
+      expect(scrollToSpy).not.toHaveBeenCalled()
     } finally {
       scrollToSpy.mockRestore()
       Object.defineProperty(window, 'scrollY', { value: 0, configurable: true })

--- a/src/controlled.tsx
+++ b/src/controlled.tsx
@@ -32,8 +32,6 @@ type ModalState = 'LOADED' | 'LOADING' | 'UNLOADED' | 'UNLOADING'
 
 interface BodyAttrs {
   overflow: string
-  position: string
-  top: string
   width: string
 }
 
@@ -44,8 +42,6 @@ interface BodyAttrs {
  */
 const defaultBodyAttrs: BodyAttrs = {
   overflow: '',
-  position: '',
-  top: '',
   width: '',
 }
 
@@ -168,7 +164,6 @@ class ControlledBase extends React.Component<
   private imgElResizeObserver: ResizeObserver | undefined
   private isScaling = false
   private prevBodyAttrs: BodyAttrs = defaultBodyAttrs
-  private prevScrollY = 0
   private styleModalImg: StyleObject = {}
   private touchYStart?: number
   private touchYEnd?: number
@@ -824,26 +819,22 @@ class ControlledBase extends React.Component<
   // ===========================================================================
 
   /**
-   * Disable body scrolling
+   * Disable body scrolling with `overflow: hidden` only — no `position: fixed`,
+   * which would zero `window.scrollY` and fire scroll events that break
+   * scroll-driven UI (#1085). iOS pinch-pan (#1060) is handled by the
+   * `handleWheel` pinch guards + the modal's `overscroll-behavior: none`.
    */
   bodyScrollDisable = (): void => {
     const bodyStyle = document.body.style
     this.prevBodyAttrs = {
       overflow: bodyStyle.overflow,
-      position: bodyStyle.position,
-      top: bodyStyle.top,
       width: bodyStyle.width,
     }
-
-    const scrollY = window.scrollY
-    this.prevScrollY = scrollY
 
     // Get clientWidth before changing styles to avoid scrollbar shift
     const clientWidth = document.body.clientWidth
 
     bodyStyle.overflow = 'hidden'
-    bodyStyle.position = 'fixed'
-    bodyStyle.top = `-${scrollY}px`
     bodyStyle.width = `${clientWidth}px`
   }
 
@@ -854,15 +845,8 @@ class ControlledBase extends React.Component<
     const bodyStyle = document.body.style
     const prev = this.prevBodyAttrs
     bodyStyle.width = prev.width
-    bodyStyle.position = prev.position
-    bodyStyle.top = prev.top
     bodyStyle.overflow = prev.overflow
-    // `behavior: 'instant'` so restoring the scroll position is not animated by
-    // a page-level `scroll-behavior: smooth`, which would otherwise scroll from
-    // the top of the document down to the previous position (#1085).
-    window.scrollTo({ left: 0, top: this.prevScrollY, behavior: 'instant' })
     this.prevBodyAttrs = defaultBodyAttrs
-    this.prevScrollY = 0
   }
 
   // ===========================================================================

--- a/stories/Img.stories.tsx
+++ b/stories/Img.stories.tsx
@@ -869,31 +869,106 @@ function CardItem({
 // =============================================================================
 
 /**
- * Manual regression demo for #1085: with `scroll-behavior: smooth`, closing the
- * zoom must restore the scroll position instantly, with no animated jump.
+ * Manual regression demo for the #1085 follow-up: opening/closing the zoom must
+ * not perturb `window.scrollY` or fire phantom `scroll` events, or
+ * scroll-position-driven UI reacts as if the user scrolled. The header collapses
+ * on scroll; the "phantom" counter must stay 0 across a zoom cycle.
  * https://github.com/rpearce/react-medium-image-zoom/issues/1085
  */
-export const ScrollRestoreOnClose: Story = props => {
-  // #1085 only reproduces with smooth scrolling enabled.
+export const ScrollPositionUiStaysStable: Story = props => {
+  const threshold = 200
+  const [scrollY, setScrollY] = React.useState(0)
+  const [scrollEvents, setScrollEvents] = React.useState(0)
+  const [phantomEvents, setPhantomEvents] = React.useState(0)
+  const zoomWindowRef = React.useRef(false)
+
   React.useEffect(() => {
-    const html = document.documentElement
-    const prev = html.style.scrollBehavior
-    html.style.scrollBehavior = 'smooth'
+    const handleScroll = (): void => {
+      setScrollY(window.scrollY)
+      setScrollEvents(n => n + 1)
+
+      // A scroll event firing while a zoom is opening/closing is a phantom: the
+      // user did not scroll, so off iOS this must never happen.
+      if (zoomWindowRef.current) {
+        setPhantomEvents(n => n + 1)
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
 
     return () => {
-      html.style.scrollBehavior = prev
+      window.removeEventListener('scroll', handleScroll)
     }
   }, [])
 
+  const handleZoomChange = (active: boolean): void => {
+    if (active) {
+      zoomWindowRef.current = true
+    } else {
+      // Keep the window open briefly so the close-time restore scroll event (if
+      // any) is still attributed to this zoom cycle.
+      window.setTimeout(() => {
+        zoomWindowRef.current = false
+      }, 150)
+    }
+  }
+
+  const isCompact = scrollY > threshold
+
   return (
     <main aria-label="Story">
-      <div style={{ padding: 16, maxWidth: 640 }}>
-        <h1>Scroll restore on close (#1085)</h1>
-        <p>
-          Scroll down to the image, zoom it, then close it. Your position should
-          restore <strong>instantly</strong> — no jump — even though this page
-          uses <code>scroll-behavior: smooth</code>.
-        </p>
+      <header
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 1,
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 16,
+          alignItems: 'center',
+          padding: isCompact ? '8px 16px' : '24px 16px',
+          background: isCompact ? '#1f2937' : '#2563eb',
+          color: '#fff',
+          fontFamily: 'sans-serif',
+          transition: 'padding 250ms ease, background 250ms ease',
+        }}
+      >
+        <strong
+          style={{
+            fontSize: isCompact ? 16 : 22,
+            transition: 'font-size 250ms ease',
+          }}
+        >
+          {isCompact ? 'Header — COMPACT' : 'Header — EXPANDED'}
+        </strong>
+        <span>scrollY: {Math.round(scrollY)}</span>
+        <span>scroll events: {scrollEvents}</span>
+        <span style={{ color: phantomEvents > 0 ? '#fca5a5' : '#86efac' }}>
+          phantom (during zoom): {phantomEvents}
+        </span>
+      </header>
+
+      <div style={{ padding: '96px 16px 16px', maxWidth: 640 }}>
+        <h1>Scroll-position UI stays stable across zoom (#1085)</h1>
+        <ol>
+          <li>
+            Scroll down until the header collapses to <strong>COMPACT</strong>{' '}
+            (scrollY &gt; {threshold}).
+          </li>
+          <li>Without scrolling further, zoom the image, then close it.</li>
+          <li>
+            ✅ Fixed: the header stays COMPACT, <code>scrollY</code> is
+            unchanged, and <strong>phantom (during zoom)</strong> stays{' '}
+            <strong>0</strong>.
+          </li>
+          <li>
+            ❌ Before the fix: the header flickered EXPANDED→COMPACT and the
+            phantom counter jumped by 2 each cycle (the body scroll-lock used{' '}
+            <code>position: fixed</code>, which zeroed <code>scrollY</code>).
+          </li>
+        </ol>
       </div>
 
       <div
@@ -911,7 +986,7 @@ export const ScrollRestoreOnClose: Story = props => {
       </div>
 
       <div style={{ padding: 16, maxWidth: 640 }}>
-        <Zoom {...props}>
+        <Zoom {...props} onZoomChange={handleZoomChange}>
           <img
             alt={imgThatWanakaTree.alt}
             src={imgThatWanakaTree.src}
@@ -925,7 +1000,8 @@ export const ScrollRestoreOnClose: Story = props => {
     </main>
   )
 }
-ScrollRestoreOnClose.parameters = { layout: 'fullscreen' }
+ScrollPositionUiStaysStable.storyName = 'Scroll Position UI Stays Stable'
+ScrollPositionUiStaysStable.parameters = { layout: 'fullscreen' }
 
 // =============================================================================
 // INTERACTIONS


### PR DESCRIPTION
## Description

Fixes https://github.com/rpearce/react-medium-image-zoom/issues/1085 (again) by walking back code introduced in https://github.com/rpearce/react-medium-image-zoom/pull/1072 that set the body to `position: fixed`, effectively zeroing out the page's `scrollY` and needing it to get resolved through hackery. It seems that the `position:fixed` and `top` code on `body` was unnecessary to fix the pinch-to-zoom-and-pan-around problem from https://github.com/rpearce/react-medium-image-zoom/issues/1060.

## Testing

1. Check out this branch
2. `pnpm start`
3. Connect to the local server:port from an iOS device and test pinching to zoom in, panning around, and unpinching to zoom out.