### PR TITLE
fix: rm invalid aria-owns usage

### DIFF
--- a/.changeset/easy-games-begin.md
+++ b/.changeset/easy-games-begin.md
@@ -1,0 +1,5 @@
+---
+'react-medium-image-zoom': patch
+---
+
+remove invalid aria-owns usage

--- a/src/controlled.tsx
+++ b/src/controlled.tsx
@@ -330,7 +330,7 @@ class ControlledBase extends React.Component<
     // =========================================================================
 
     return (
-      <WrapElement aria-owns={idModal} data-rmiz="" ref={refWrap}>
+      <WrapElement data-rmiz="" ref={refWrap}>
         <WrapElement
           data-rmiz-content={dataContentState}
           ref={refContent}
@@ -357,7 +357,7 @@ class ControlledBase extends React.Component<
               aria-modal="true"
               className={classDialog}
               data-rmiz-modal=""
-              id={idModal}
+              id={idModal} /* not referenced here; keep for backwards compat */
               onClick={handleDialogClick}
               onClose={handleDialogClose}
               onCancel={handleDialogCancelStatic}


### PR DESCRIPTION
## Description

I got a report that `aria-owns` was pointing to a `display:none` hidden modal dialog element, which is true, but it made me realize that there's a bit of a logic problem here:

* not zoomed? ➡️ modal is hidden, `aria-owns` on parent is pointless
* zoomed? ➡️ modal is visible, `aria-owns` parent is now hidden, so pointless

There isn't a case where the modal is visible at the same time as `aria-owns`, so I think we're good to remove it.